### PR TITLE
feat(flag): ignore home err

### DIFF
--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -24,11 +24,7 @@ func Config(args []string) (string, error) {
 		return "", err
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
+	home, _ := os.UserHomeDir()
 	config := cmp.Or(
 		file,
 		os.Getenv("TAUSCH_CONFIG"),


### PR DESCRIPTION
If home is not defined it will look in the current folder the binary is in.
