### PR TITLE
fix(cmd): route flag parse output through cli stderr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vendor
 *.xml
 tausch
 dist
+test/reports/coverage.html
+.source-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ skill.
 
 ### Prereqs
 
-- Go toolchain: `go.mod` declares `go 1.25.0`.
+- Go toolchain: `go.mod` declares `go 1.26.0`.
 - Some Make targets come from the `bin/` git submodule (see `.gitmodules`). If targets fail with missing files, initialize the submodule first:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ The executable will read the config from the following places:
 
 Using the library will look for the executable in the following places:
 
-- `TAUSCH_PATH` - the path of the binary.
-- `$PATH`: - finds the executable provided in the path.
+- `$PATH` - finds the executable provided in the path.
+- `TAUSCH_PATH` - the path of the binary if `tausch` is not found on `PATH`.
 
 ### Command
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -38,7 +38,7 @@ import (
 // YAML, or looking up the command is returned with an exit code of 0 (callers
 // should treat a non-nil error as failure regardless of the code).
 func Run(stdout, stderr io.Writer, args []string) (int, error) {
-	f, err := flag.Parse(args)
+	f, err := flag.Parse(stderr, args)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -10,12 +10,15 @@ import (
 
 func TestRunInvalidArgs(t *testing.T) {
 	args := []string{"- x"}
-	b := &bytes.Buffer{}
-	c, err := cmd.Run(b, b, args)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	c, err := cmd.Run(stdout, stderr, args)
 
 	require.Error(t, err)
 	require.Zero(t, c)
-	require.Empty(t, b.Bytes())
+	require.Empty(t, stdout.Bytes())
+	require.Contains(t, stderr.String(), "flag provided but not defined")
+	require.Contains(t, stderr.String(), "Usage of tausch:")
 }
 
 func TestRunMissingConfig(t *testing.T) {
@@ -24,12 +27,14 @@ func TestRunMissingConfig(t *testing.T) {
 		"--",
 		"test", "my", "code",
 	}
-	b := &bytes.Buffer{}
-	c, err := cmd.Run(b, b, args)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	c, err := cmd.Run(stdout, stderr, args)
 
 	require.Error(t, err)
 	require.Zero(t, c)
-	require.Empty(t, b.Bytes())
+	require.Empty(t, stdout.Bytes())
+	require.Empty(t, stderr.Bytes())
 }
 
 func TestRunMissingCommand(t *testing.T) {
@@ -38,12 +43,14 @@ func TestRunMissingCommand(t *testing.T) {
 		"--",
 		"test", "my", "code",
 	}
-	b := &bytes.Buffer{}
-	c, err := cmd.Run(b, b, args)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	c, err := cmd.Run(stdout, stderr, args)
 
 	require.Error(t, err)
 	require.Zero(t, c)
-	require.Empty(t, b.Bytes())
+	require.Empty(t, stdout.Bytes())
+	require.Empty(t, stderr.Bytes())
 }
 
 func TestRunStdout(t *testing.T) {
@@ -52,12 +59,14 @@ func TestRunStdout(t *testing.T) {
 		"--",
 		"go", "version",
 	}
-	b := &bytes.Buffer{}
-	c, err := cmd.Run(b, b, args)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	c, err := cmd.Run(stdout, stderr, args)
 
 	require.NoError(t, err)
 	require.Zero(t, c)
-	require.NotEmpty(t, b.Bytes())
+	require.NotEmpty(t, stdout.Bytes())
+	require.Empty(t, stderr.Bytes())
 }
 
 func TestRunStderr(t *testing.T) {
@@ -66,10 +75,12 @@ func TestRunStderr(t *testing.T) {
 		"--",
 		"go", "bob",
 	}
-	b := &bytes.Buffer{}
-	c, err := cmd.Run(b, b, args)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	c, err := cmd.Run(stdout, stderr, args)
 
 	require.NoError(t, err)
 	require.Equal(t, 1, c)
-	require.NotEmpty(t, b.Bytes())
+	require.Empty(t, stdout.Bytes())
+	require.NotEmpty(t, stderr.Bytes())
 }

--- a/internal/flag/values.go
+++ b/internal/flag/values.go
@@ -3,6 +3,7 @@ package flag
 import (
 	"cmp"
 	"flag"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -12,6 +13,7 @@ import (
 //
 // Parsing uses a dedicated FlagSet configured with flag.ContinueOnError, so
 // parsing errors are returned to the caller rather than terminating the process.
+// Any parse error or usage output produced by the FlagSet is written to output.
 //
 // The tausch CLI is typically invoked as:
 //
@@ -19,8 +21,9 @@ import (
 //
 // After parsing flags, the remaining arguments (typically those after `--`) are
 // preserved and used to derive the command name via [Values.Name].
-func Parse(args []string) (*Values, error) {
+func Parse(output io.Writer, args []string) (*Values, error) {
 	set := flag.NewFlagSet("tausch", flag.ContinueOnError)
+	set.SetOutput(output)
 
 	file := set.String("config", "", "the config file path")
 	if err := set.Parse(args); err != nil {

--- a/internal/flag/values_test.go
+++ b/internal/flag/values_test.go
@@ -1,6 +1,7 @@
 package flag_test
 
 import (
+	"io"
 	"testing"
 
 	"github.com/alexfalkowski/tausch/internal/flag"
@@ -10,7 +11,7 @@ import (
 func TestValuesSuccess(t *testing.T) {
 	args := []string{"-config", "cfg.yml", "test", "my", "code"}
 
-	f, err := flag.Parse(args)
+	f, err := flag.Parse(io.Discard, args)
 	require.NoError(t, err)
 
 	c, err := f.Config()
@@ -24,6 +25,6 @@ func TestValuesSuccess(t *testing.T) {
 func TestValuesError(t *testing.T) {
 	args := []string{"- x"}
 
-	_, err := flag.Parse(args)
+	_, err := flag.Parse(io.Discard, args)
 	require.Error(t, err)
 }


### PR DESCRIPTION
## What

- Updated [internal/flag/values.go](/Users/alejandro/code/tausch/internal/flag/values.go) so `Parse` accepts an output writer and routes `flag` package usage/error text through that writer.
- Updated [internal/cmd/cmd.go](/Users/alejandro/code/tausch/internal/cmd/cmd.go) to pass the CLI `stderr` writer into `flag.Parse`, so parse failures stay inside the command’s explicit output contract.
- Strengthened [internal/cmd/cmd_test.go](/Users/alejandro/code/tausch/internal/cmd/cmd_test.go) to assert stdout/stderr routing for invalid args, missing config, missing command, success, and failure cases.
- Updated [internal/flag/values_test.go](/Users/alejandro/code/tausch/internal/flag/values_test.go) for the new `Parse` signature.
- Fixed documentation drift in [README.md](/Users/alejandro/code/tausch/README.md) for `PATH` vs `TAUSCH_PATH` lookup order and in [AGENTS.md](/Users/alejandro/code/tausch/AGENTS.md) for the declared Go version.
- Added local artifact ignores in [.gitignore](/Users/alejandro/code/tausch/.gitignore) for `test/reports/coverage.html` and `.source-key`.

## Why

- Parse failures were leaking directly to process stderr even when `cmd.Run` was given explicit writers, which broke the intended CLI abstraction and made the invalid-args path inconsistent with the rest of the command flow.
- The tests now lock in the writer-routing behavior so this regression is less likely to come back.
- The doc updates keep contributor and user guidance aligned with the implementation.
- The `.gitignore` additions prevent generated local files from showing up as accidental changes.

## Testing

- `make lint`
- `env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/gomod GOTMPDIR=/tmp go test ./internal/flag ./internal/cmd`
- `env GOCACHE=/tmp/go-build GOTMPDIR=/tmp go test ./...`
- `make specs`
- `env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/gomod GOTMPDIR=/tmp go build`