### PR TITLE
fix(cmd): make cmd run own cli error output

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -29,41 +29,55 @@ import (
 //
 // Run returns an integer exit code intended to be used as the process exit code:
 //
+//   - If argument parsing fails, the flag package writes usage/error output to
+//     stderr and Run returns 1.
+//   - If config resolution, config decoding, command lookup, or stdout/stderr
+//     decode/write steps fail, Run writes the error to stderr and returns 1.
 //   - If the command's configured `stdout` is non-empty and is successfully
-//     written, Run returns (0, nil).
-//   - Otherwise, Run attempts to write the configured `stderr` and returns
-//     (1, err) where err is any error from decoding or writing stderr.
+//     written, Run returns 0.
+//   - Otherwise, Run writes the configured `stderr` payload and returns 1.
 //
-// Any error encountered while parsing flags, resolving the config path, decoding
-// YAML, or looking up the command is returned with an exit code of 0 (callers
-// should treat a non-nil error as failure regardless of the code).
-func Run(stdout, stderr io.Writer, args []string) (int, error) {
+// Run owns user-facing error output for the CLI flow; callers should treat the
+// returned status code as the complete result.
+func Run(stdout, stderr io.Writer, args []string) int {
 	f, err := flag.Parse(stderr, args)
 	if err != nil {
-		return 0, err
+		return 1
 	}
 
 	file, err := f.Config()
 	if err != nil {
-		return 0, err
+		fmt.Fprintln(stderr, err)
+		return 1
 	}
 
 	config, err := config.Decode(file)
 	if err != nil {
-		return 0, err
+		fmt.Fprintln(stderr, err)
+		return 1
 	}
 
 	name := f.Name()
 	command, err := config.GetCommand(name)
 	if err != nil {
-		return 0, fmt.Errorf("find %s: %w", name, err)
+		fmt.Fprintln(stderr, fmt.Errorf("find %s: %w", name, err))
+		return 1
 	}
 
 	ok, err := io.Write(stdout, command.Stdout)
-	if err != nil || ok {
-		return 0, err
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+
+	if ok {
+		return 0
 	}
 
 	_, err = io.Write(stderr, command.Stderr)
-	return 1, err
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+	}
+
+	return 1
 }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -12,13 +12,25 @@ func TestRunInvalidArgs(t *testing.T) {
 	args := []string{"- x"}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	c, err := cmd.Run(stdout, stderr, args)
+	c := cmd.Run(stdout, stderr, args)
 
-	require.Error(t, err)
-	require.Zero(t, c)
+	require.Equal(t, 1, c)
 	require.Empty(t, stdout.Bytes())
 	require.Contains(t, stderr.String(), "flag provided but not defined")
 	require.Contains(t, stderr.String(), "Usage of tausch:")
+}
+
+func TestRunConfigError(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	c := cmd.Run(stdout, stderr, nil)
+
+	require.Equal(t, 1, c)
+	require.Empty(t, stdout.Bytes())
+	require.NotEmpty(t, stderr.Bytes())
 }
 
 func TestRunMissingConfig(t *testing.T) {
@@ -29,12 +41,11 @@ func TestRunMissingConfig(t *testing.T) {
 	}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	c, err := cmd.Run(stdout, stderr, args)
+	c := cmd.Run(stdout, stderr, args)
 
-	require.Error(t, err)
-	require.Zero(t, c)
+	require.Equal(t, 1, c)
 	require.Empty(t, stdout.Bytes())
-	require.Empty(t, stderr.Bytes())
+	require.Contains(t, stderr.String(), "cfg.yml")
 }
 
 func TestRunMissingCommand(t *testing.T) {
@@ -45,12 +56,26 @@ func TestRunMissingCommand(t *testing.T) {
 	}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	c, err := cmd.Run(stdout, stderr, args)
+	c := cmd.Run(stdout, stderr, args)
 
-	require.Error(t, err)
-	require.Zero(t, c)
+	require.Equal(t, 1, c)
 	require.Empty(t, stdout.Bytes())
-	require.Empty(t, stderr.Bytes())
+	require.Contains(t, stderr.String(), "find test my code: command not found")
+}
+
+func TestRunStdoutWriteError(t *testing.T) {
+	args := []string{
+		"-config", "../../test/configs/stdout_invalid.yml",
+		"--",
+		"go", "version",
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	c := cmd.Run(stdout, stderr, args)
+
+	require.Equal(t, 1, c)
+	require.Empty(t, stdout.Bytes())
+	require.Contains(t, stderr.String(), "illegal base64 data")
 }
 
 func TestRunStdout(t *testing.T) {
@@ -61,12 +86,26 @@ func TestRunStdout(t *testing.T) {
 	}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	c, err := cmd.Run(stdout, stderr, args)
+	c := cmd.Run(stdout, stderr, args)
 
-	require.NoError(t, err)
 	require.Zero(t, c)
 	require.NotEmpty(t, stdout.Bytes())
 	require.Empty(t, stderr.Bytes())
+}
+
+func TestRunStderrWriteError(t *testing.T) {
+	args := []string{
+		"-config", "../../test/configs/stderr_invalid.yml",
+		"--",
+		"go", "bob",
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	c := cmd.Run(stdout, stderr, args)
+
+	require.Equal(t, 1, c)
+	require.Empty(t, stdout.Bytes())
+	require.Contains(t, stderr.String(), "illegal base64 data")
 }
 
 func TestRunStderr(t *testing.T) {
@@ -77,9 +116,8 @@ func TestRunStderr(t *testing.T) {
 	}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	c, err := cmd.Run(stdout, stderr, args)
+	c := cmd.Run(stdout, stderr, args)
 
-	require.NoError(t, err)
 	require.Equal(t, 1, c)
 	require.Empty(t, stdout.Bytes())
 	require.NotEmpty(t, stderr.Bytes())

--- a/main.go
+++ b/main.go
@@ -1,17 +1,11 @@
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/alexfalkowski/tausch/internal/cmd"
 )
 
 func main() {
-	code, err := cmd.Run(os.Stdout, os.Stderr, os.Args[1:])
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	os.Exit(code)
+	os.Exit(cmd.Run(os.Stdout, os.Stderr, os.Args[1:]))
 }

--- a/test/configs/stderr_invalid.yml
+++ b/test/configs/stderr_invalid.yml
@@ -1,0 +1,3 @@
+cmds:
+  - name: go bob
+    stderr: "base64:!!!"

--- a/test/configs/stdout_invalid.yml
+++ b/test/configs/stdout_invalid.yml
@@ -1,0 +1,3 @@
+cmds:
+  - name: go version
+    stdout: "base64:!!!"


### PR DESCRIPTION
## What

- Refactored [internal/cmd/cmd.go](/Users/alejandro/code/tausch/internal/cmd/cmd.go) so `Run` owns CLI-facing error output and returns only an exit code.
- Simplified [main.go](/Users/alejandro/code/tausch/main.go) to `os.Exit(cmd.Run(...))`, removing caller knowledge of command/parser internals.
- Updated [internal/cmd/cmd_test.go](/Users/alejandro/code/tausch/internal/cmd/cmd_test.go) to assert the CLI contract directly: exit status plus stdout/stderr output.
- Added invalid fixture configs in [stdout_invalid.yml](/Users/alejandro/code/tausch/test/configs/stdout_invalid.yml) and [stderr_invalid.yml](/Users/alejandro/code/tausch/test/configs/stderr_invalid.yml) so the new error-path coverage uses repo fixtures instead of inline temp YAML.

## Why

- The previous shape split responsibility awkwardly between `cmd.Run` and `main`, forcing the caller to understand which errors had already been rendered.
- Centralizing output in `cmd.Run` makes the CLI flow easier to reason about and keeps `main` as a minimal entrypoint.
- The added tests close the branch-coverage gap introduced by the clearer control flow and keep `internal/cmd.Run` fully covered.

## Testing

- `env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/gomod GOTMPDIR=/tmp go test ./internal/cmd -coverprofile=/tmp/cmd.cov`
- `env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/gomod GOTMPDIR=/tmp go tool cover -func=/tmp/cmd.cov`
- `env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/gomod GOTMPDIR=/tmp go test ./internal/flag ./internal/cmd ./exec`
- `make lint`
- `env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/gomod GOTMPDIR=/tmp go run . -bad`