### PR TITLE
docs(readme): correct cmd run package contract

### DIFF
--- a/internal/cmd/doc.go
+++ b/internal/cmd/doc.go
@@ -30,7 +30,7 @@
 //
 // # Exit codes
 //
-// [Run] returns an integer exit code and an error.
+// [Run] returns an integer exit code.
 //
 // In normal operation:
 //
@@ -39,7 +39,7 @@
 //   - Otherwise, it attempts to write the configured `stderr` value and returns
 //     exit code 1.
 //
-// Errors are returned for failures such as flag parsing problems, missing or
-// unreadable configuration, YAML decoding errors, command lookup failures, or
-// decode/write errors while emitting stdout/stderr.
+// Failures such as flag parsing problems, missing or unreadable configuration,
+// YAML decoding errors, command lookup failures, or decode/write errors while
+// emitting stdout/stderr are written to stderr and reported with exit code 1.
 package cmd


### PR DESCRIPTION
## What

Corrected the `internal/cmd` package documentation for `Run`.

## Why

The package docs said `Run` returns an error, but the implementation returns only an exit code and writes failures to stderr.

## Testing

`go test ./internal/cmd` passed.