### PR TITLE
fix(config): nil command lookup panic

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,7 +61,9 @@ type Config struct {
 //
 // If no command matches, the error will be [ErrCommandNotFound].
 func (c *Config) GetCommand(name string) (*Command, error) {
-	i := slices.IndexFunc(c.Cmds, func(c *Command) bool { return c.Name == name })
+	i := slices.IndexFunc(c.Cmds, func(command *Command) bool {
+		return command != nil && command.Name == name
+	})
 	if i == -1 {
 		return nil, ErrCommandNotFound
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,3 +27,12 @@ func TestDecodeError(t *testing.T) {
 		require.Nil(t, c)
 	}
 }
+
+func TestGetCommandNilCommand(t *testing.T) {
+	c := &config.Config{Cmds: []*config.Command{nil}}
+
+	command, err := c.GetCommand("go version")
+
+	require.Nil(t, command)
+	require.ErrorIs(t, err, config.ErrCommandNotFound)
+}


### PR DESCRIPTION
## What

Updated `GetCommand` to skip nil command entries when searching config commands.

Added a regression test for nil command entries returning `ErrCommandNotFound`.

## Why

Malformed YAML can decode `cmds` entries as nil, and lookup previously dereferenced them, causing a panic.

## Testing

`make dep` passed.

`go test ./internal/config` passed.

`go test ./...` passed.

`make lint` passed with `0 issues.`