### PR TITLE
fix(flag): config path precedence

### DIFF
--- a/internal/flag/values.go
+++ b/internal/flag/values.go
@@ -1,7 +1,6 @@
 package flag
 
 import (
-	"cmp"
 	"flag"
 	"io"
 	"os"
@@ -55,17 +54,20 @@ type Values struct {
 // callers should expect failures when opening/decoding the file if the path is
 // invalid.
 func (f *Values) Config() (string, error) {
+	if f.file != "" {
+		return f.file, nil
+	}
+
+	if config := os.Getenv("TAUSCH_CONFIG"); config != "" {
+		return config, nil
+	}
+
 	dir, err := os.UserConfigDir()
 	if err != nil {
 		return "", err
 	}
 
-	config := cmp.Or(
-		f.file,
-		os.Getenv("TAUSCH_CONFIG"),
-		path.Join(dir, "tausch", "config.yml"),
-	)
-	return config, nil
+	return path.Join(dir, "tausch", "config.yml"), nil
 }
 
 // Name returns the command name derived from the remaining (non-flag) arguments.

--- a/internal/flag/values_test.go
+++ b/internal/flag/values_test.go
@@ -2,6 +2,8 @@ package flag_test
 
 import (
 	"io"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/alexfalkowski/tausch/internal/flag"
@@ -20,6 +22,79 @@ func TestValuesSuccess(t *testing.T) {
 
 	name := f.Name()
 	require.Equal(t, "test my code", name)
+}
+
+func TestValuesConfig(t *testing.T) {
+	tests := []configCase{
+		{
+			name:      "flag takes precedence with missing user config dir",
+			envConfig: "env.yml",
+			want:      "cfg.yml",
+			args:      []string{"-config", "cfg.yml"},
+		},
+		{
+			name:      "env takes precedence with missing user config dir",
+			envConfig: "env.yml",
+			want:      "env.yml",
+		},
+		{
+			name:         "default errors with missing user config dir",
+			requireError: true,
+		},
+		{
+			name:        "default uses user config dir",
+			useHome:     true,
+			wantDefault: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assert(t)
+		})
+	}
+}
+
+type configCase struct {
+	name         string
+	envConfig    string
+	want         string
+	args         []string
+	useHome      bool
+	wantDefault  bool
+	requireError bool
+}
+
+func (c configCase) assert(t *testing.T) {
+	t.Helper()
+
+	if c.useHome {
+		t.Setenv("HOME", t.TempDir())
+	} else {
+		t.Setenv("HOME", "")
+	}
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("TAUSCH_CONFIG", c.envConfig)
+
+	f, err := flag.Parse(io.Discard, c.args)
+	require.NoError(t, err)
+
+	config, err := f.Config()
+	if c.requireError {
+		require.Error(t, err)
+		require.Empty(t, config)
+		return
+	}
+
+	require.NoError(t, err)
+	if c.wantDefault {
+		configDir, err := os.UserConfigDir()
+		require.NoError(t, err)
+		require.Equal(t, path.Join(configDir, "tausch", "config.yml"), config)
+		return
+	}
+
+	require.Equal(t, c.want, config)
 }
 
 func TestValuesError(t *testing.T) {


### PR DESCRIPTION
## What

Updated config path resolution so `-config` is returned first, then `TAUSCH_CONFIG`, and the default user config path is only resolved when neither explicit source is set.

Added tests for explicit config paths with unavailable user config directories and default config path behavior.

## Why

Explicit config sources should not fail just because the default user config directory cannot be resolved.

## Testing

`make dep` passed.

`go test ./internal/flag` passed.

`go test ./...` passed.

`make lint` passed with `0 issues.`