### PR TITLE
feat(command): reject configs with conflicting outputs

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -63,6 +63,21 @@ func TestRunMissingCommand(t *testing.T) {
 	require.Contains(t, stderr.String(), "find test my code: command not found")
 }
 
+func TestRunMultipleOutputs(t *testing.T) {
+	args := []string{
+		"-config", "../../test/configs/multiple_outputs.yml",
+		"--",
+		"go", "version",
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	c := cmd.Run(stdout, stderr, args)
+
+	require.Equal(t, 1, c)
+	require.Empty(t, stdout.Bytes())
+	require.Contains(t, stderr.String(), "multiple outputs configured")
+}
+
 func TestRunStdoutWriteError(t *testing.T) {
 	args := []string{
 		"-config", "../../test/configs/stdout_invalid.yml",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"slices"
 
@@ -14,11 +15,19 @@ import (
 // Callers typically compare with errors.Is(err, ErrCommandNotFound).
 var ErrCommandNotFound = errors.New("command not found")
 
+// ErrMultipleOutputs is returned when a command configures both stdout and
+// stderr. A command stub must choose one output stream because stdout indicates
+// success and stderr indicates failure.
+//
+// Callers typically compare with errors.Is(err, ErrMultipleOutputs).
+var ErrMultipleOutputs = errors.New("multiple outputs configured")
+
 // Decode reads a YAML configuration file from path and decodes it into a [Config].
 //
 // The YAML is expected to match the tausch schema (a top-level `cmds` list). This
-// function only performs YAML decoding; it does not validate that any commands
-// are present or that stdout/stderr payload strings are valid `kind:data` values.
+// function validates command-level invariants, but it does not validate that any
+// commands are present or that stdout/stderr payload strings are valid
+// `kind:data` values.
 //
 // The returned *Config is ready to be queried with [Config.GetCommand].
 //
@@ -36,6 +45,10 @@ func Decode(path string) (*Config, error) {
 		return nil, err
 	}
 
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
 	return &config, nil
 }
 
@@ -49,6 +62,24 @@ func Decode(path string) (*Config, error) {
 type Config struct {
 	// Cmds is the set of configured command stubs.
 	Cmds []*Command `yaml:"cmds"`
+}
+
+// Validate checks command-level config invariants.
+//
+// It permits nil command entries so lookup remains tolerant of sparse decoded
+// data, but non-nil commands must not configure both stdout and stderr.
+func (c *Config) Validate() error {
+	for _, command := range c.Cmds {
+		if command == nil {
+			continue
+		}
+
+		if command.hasMultipleOutputs() {
+			return fmt.Errorf("command %q: %w", command.Name, ErrMultipleOutputs)
+		}
+	}
+
+	return nil
 }
 
 // GetCommand returns the configured [Command] whose [Command.Name] exactly matches
@@ -89,4 +120,8 @@ type Command struct {
 	// Stderr is the encoded payload to write to stderr when stdout is empty and the
 	// command is treated as failing.
 	Stderr string `yaml:"stderr"`
+}
+
+func (c *Command) hasMultipleOutputs() bool {
+	return c.Stdout != "" && c.Stderr != ""
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,6 +28,14 @@ func TestDecodeError(t *testing.T) {
 	}
 }
 
+func TestDecodeMultipleOutputs(t *testing.T) {
+	c, err := config.Decode("../../test/configs/multiple_outputs.yml")
+
+	require.Nil(t, c)
+	require.ErrorIs(t, err, config.ErrMultipleOutputs)
+	require.Contains(t, err.Error(), `command "go version"`)
+}
+
 func TestGetCommandNilCommand(t *testing.T) {
 	c := &config.Config{Cmds: []*config.Command{nil}}
 

--- a/test/configs/multiple_outputs.yml
+++ b/test/configs/multiple_outputs.yml
@@ -1,0 +1,4 @@
+cmds:
+  - name: go version
+    stdout: text:go version
+    stderr: text:warning


### PR DESCRIPTION
## What

- reject config entries that set both stdout and stderr
- expose a config error for conflicting output streams
- add config and CLI coverage with an invalid fixture

## Why

stdout and stderr are mutually exclusive in tausch because stdout drives the success path and stderr drives the failure path. Rejecting configs with both fields set makes that contract explicit before execution.

## Testing

- `go test ./...`
- `gmake lint` passed with the existing `gomodguard` deprecation warning and reported `0 issues`.

AI-assisted-by: [Codex](https://openai.com/codex/)
