### PR TITLE
feat(encoding): reject malformed payload values

### DIFF
--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -26,12 +26,17 @@ var ErrKindNotFound = errors.New("kind not found")
 //   - "file": treats data as a filesystem path and returns the file contents.
 //   - "base64": treats data as standard base64 and decodes it.
 //
-// If kind is unknown, Decode returns ErrKindNotFound.
+// If the value is missing the ":" separator or kind is unknown, Decode returns
+// ErrKindNotFound.
 //
 // If kind is "file", any error from os.ReadFile is returned.
 // If kind is "base64", any error from base64.StdEncoding.DecodeString is returned.
 func Decode(value string) ([]byte, error) {
-	kind, data, _ := strings.Cut(value, ":")
+	kind, data, ok := strings.Cut(value, ":")
+	if !ok {
+		return nil, ErrKindNotFound
+	}
+
 	switch kind {
 	case "text":
 		return []byte(data), nil

--- a/internal/encoding/encoding_test.go
+++ b/internal/encoding/encoding_test.go
@@ -35,3 +35,16 @@ func TestDecodeError(t *testing.T) {
 		require.Error(t, err)
 	}
 }
+
+func TestDecodeMissingSeparator(t *testing.T) {
+	values := []string{
+		"text",
+		"base64",
+		"file",
+	}
+
+	for _, value := range values {
+		_, err := encoding.Decode(value)
+		require.ErrorIs(t, err, encoding.ErrKindNotFound)
+	}
+}


### PR DESCRIPTION
## What

- reject payload values that are missing the `kind:data` separator
- return `ErrKindNotFound` for malformed payload shapes before kind dispatch
- add tests for missing separators across supported kinds

## Why

Payloads without a colon could previously be treated as known kinds with empty data. That made malformed values such as `base64` decode successfully as empty output instead of failing fast.

## Testing

- `go test ./...`
- `gmake lint` passed with the existing `gomodguard` deprecation warning and reported `0 issues`.

AI-assisted-by: [Codex](https://openai.com/codex/)
