### PR TITLE
test(feature): cover command stub edge cases

### DIFF
--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -17,6 +17,30 @@ func TestPathCommandSuccess(t *testing.T) {
 	t.Setenv("PATH", root)
 	t.Setenv("TAUSCH_CONFIG", "../test/configs/exec.yml")
 
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := exec.CommandContext(t.Context(), "go", "version")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	require.NoError(t, cmd.Run())
+	require.NoError(t, cmd.Err)
+	require.Equal(t, readFixture(t, "../test/stdout/go_version.txt"), stdout.Bytes())
+	require.Empty(t, stderr.Bytes())
+}
+
+func TestCommandPrefersPathOverTauschPath(t *testing.T) {
+	pathDir := t.TempDir()
+	path := filepath.Join(pathDir, "tausch")
+	fallback := filepath.Join(t.TempDir(), "tausch")
+
+	writeExecutable(t, path, "#!/bin/sh\nprintf path\n")
+	writeExecutable(t, fallback, "#!/bin/sh\nprintf fallback\n")
+
+	t.Setenv("PATH", pathDir)
+	t.Setenv("TAUSCH_PATH", fallback)
+
 	b := &bytes.Buffer{}
 
 	cmd := exec.CommandContext(t.Context(), "go", "version")
@@ -25,7 +49,7 @@ func TestPathCommandSuccess(t *testing.T) {
 
 	require.NoError(t, cmd.Run())
 	require.NoError(t, cmd.Err)
-	require.NotEmpty(t, b.Bytes())
+	require.Equal(t, "path", b.String())
 }
 
 func TestCommandSuccess(t *testing.T) {
@@ -33,15 +57,17 @@ func TestCommandSuccess(t *testing.T) {
 	t.Setenv("TAUSCH_PATH", "../tausch")
 	t.Setenv("TAUSCH_CONFIG", "../test/configs/exec.yml")
 
-	b := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
 
 	cmd := exec.CommandContext(t.Context(), "go", "version")
-	cmd.Stdout = b
-	cmd.Stderr = b
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	require.NoError(t, cmd.Run())
 	require.NoError(t, cmd.Err)
-	require.NotEmpty(t, b.Bytes())
+	require.Equal(t, readFixture(t, "../test/stdout/go_version.txt"), stdout.Bytes())
+	require.Empty(t, stderr.Bytes())
 }
 
 func TestCommandFallsBackToTauschPathForErrDot(t *testing.T) {
@@ -49,10 +75,8 @@ func TestCommandFallsBackToTauschPathForErrDot(t *testing.T) {
 	fallback := filepath.Join(t.TempDir(), "tausch")
 	local := filepath.Join(cwd, "tausch")
 
-	require.NoError(t, os.WriteFile(fallback, []byte("#!/bin/sh\nprintf fallback\n"), 0o600))
-	require.NoError(t, os.Chmod(fallback, 0o700))
-	require.NoError(t, os.WriteFile(local, []byte("#!/bin/sh\nprintf local\n"), 0o600))
-	require.NoError(t, os.Chmod(local, 0o700))
+	writeExecutable(t, fallback, "#!/bin/sh\nprintf fallback\n")
+	writeExecutable(t, local, "#!/bin/sh\nprintf local\n")
 
 	t.Chdir(cwd)
 	t.Setenv("PATH", ".")
@@ -67,6 +91,15 @@ func TestCommandFallsBackToTauschPathForErrDot(t *testing.T) {
 	require.NoError(t, cmd.Run())
 	require.NoError(t, cmd.Err)
 	require.Equal(t, "fallback", b.String())
+}
+
+func TestCommandPrefixesDelimiter(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("TAUSCH_PATH", filepath.Join(t.TempDir(), "tausch"))
+
+	cmd := exec.CommandContext(t.Context(), "-version", "--json")
+
+	require.Equal(t, []string{"--", "-version", "--json"}, cmd.Args[1:])
 }
 
 func TestCommandPassesVariadicArgs(t *testing.T) {
@@ -96,13 +129,34 @@ func TestCommandError(t *testing.T) {
 	t.Setenv("TAUSCH_PATH", "../tausch")
 	t.Setenv("TAUSCH_CONFIG", "../test/configs/exec.yml")
 
-	b := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
 
 	cmd := exec.CommandContext(t.Context(), "go", "bob")
-	cmd.Stdout = b
-	cmd.Stderr = b
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
-	require.Error(t, cmd.Run())
+	err := cmd.Run()
+	require.Error(t, err)
 	require.NoError(t, cmd.Err)
-	require.NotEmpty(t, b.Bytes())
+	require.NotNil(t, cmd.ProcessState)
+	require.Equal(t, 1, cmd.ProcessState.ExitCode())
+	require.Empty(t, stdout.Bytes())
+	require.Equal(t, readFixture(t, "../test/stderr/go_bob.txt"), stderr.Bytes())
+}
+
+func readFixture(t *testing.T, path string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return data
+}
+
+func writeExecutable(t *testing.T, path, script string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o600))
+	require.NoError(t, os.Chmod(path, 0o700))
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,3 +44,31 @@ func TestGetCommandNilCommand(t *testing.T) {
 	require.Nil(t, command)
 	require.ErrorIs(t, err, config.ErrCommandNotFound)
 }
+
+func TestGetCommandExactMatch(t *testing.T) {
+	command := &config.Command{Name: "go version", Stdout: "text:go version"}
+	c := &config.Config{
+		Cmds: []*config.Command{
+			command,
+			{Name: "Go Version", Stdout: "text:case"},
+			{Name: "go version extra", Stdout: "text:extra"},
+		},
+	}
+
+	got, err := c.GetCommand("go version")
+	require.NoError(t, err)
+	require.Same(t, command, got)
+
+	got, err = c.GetCommand("go version extra")
+	require.NoError(t, err)
+	require.Same(t, c.Cmds[2], got)
+
+	for _, value := range []string{"Go version", "go", " go version "} {
+		t.Run(value, func(t *testing.T) {
+			got, err := c.GetCommand(value)
+
+			require.Nil(t, got)
+			require.ErrorIs(t, err, config.ErrCommandNotFound)
+		})
+	}
+}

--- a/internal/encoding/encoding_test.go
+++ b/internal/encoding/encoding_test.go
@@ -1,7 +1,8 @@
 package encoding_test
 
 import (
-	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/alexfalkowski/tausch/internal/encoding"
@@ -9,17 +10,26 @@ import (
 )
 
 func TestDecodeSuccess(t *testing.T) {
-	values := []string{
-		"text:test",
-		"base64:dGVzdA==",
-		"file:../../test/configs/test.txt",
+	want := []byte(" test\n")
+	file := filepath.Join(t.TempDir(), "test.txt")
+	require.NoError(t, os.WriteFile(file, want, 0o600))
+
+	values := []struct {
+		name  string
+		value string
+	}{
+		{name: "text", value: "text: test\n"},
+		{name: "base64", value: "base64:IHRlc3QK"},
+		{name: "file", value: "file:" + file},
 	}
 
-	for _, value := range values {
-		d, err := encoding.Decode(value)
+	for _, tt := range values {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := encoding.Decode(tt.value)
 
-		require.NoError(t, err)
-		require.Equal(t, []byte("test"), bytes.TrimSpace(d))
+			require.NoError(t, err)
+			require.Equal(t, want, d)
+		})
 	}
 }
 

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -2,6 +2,8 @@ package io_test
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/alexfalkowski/tausch/internal/io"
@@ -10,19 +12,28 @@ import (
 )
 
 func TestWriteSuccess(t *testing.T) {
-	values := []string{
-		"text:test",
-		"base64:dGVzdA==",
-		"file:../../test/configs/test.txt",
+	want := []byte(" test\n")
+	file := filepath.Join(t.TempDir(), "test.txt")
+	require.NoError(t, os.WriteFile(file, want, 0o600))
+
+	values := []struct {
+		name  string
+		value string
+	}{
+		{name: "text", value: "text: test\n"},
+		{name: "base64", value: "base64:IHRlc3QK"},
+		{name: "file", value: "file:" + file},
 	}
 
-	for _, value := range values {
-		buffer := &bytes.Buffer{}
-		ok, err := io.Write(buffer, value)
+	for _, tt := range values {
+		t.Run(tt.name, func(t *testing.T) {
+			buffer := &bytes.Buffer{}
+			ok, err := io.Write(buffer, tt.value)
 
-		require.NoError(t, err)
-		require.True(t, ok)
-		require.Equal(t, []byte("test"), bytes.TrimSpace(buffer.Bytes()))
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t, want, buffer.Bytes())
+		})
 	}
 }
 


### PR DESCRIPTION
## What

- Strengthen the command wrapper coverage for executable resolution precedence, delimiter insertion, and exact stdout/stderr fixture behavior.
- Add exact command lookup assertions for near-miss command names.
- Replace trim-based payload assertions with exact-byte checks for decoded and written output.

## Why

- These cases protect documented behavior that could previously regress while tests still passed with non-empty or normalized output.
- The change keeps the scope to coverage hardening only; production behavior is unchanged.

## Testing

- `make lint` - passed
- `make build` - passed
- `go test ./...` - passed
- `git diff --check` - passed
