### PR TITLE
docs(readme): clarify tausch configuration behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Config path is resolved in this order (`internal/flag/values.go:29-42`):
 
 1. `-config <path>`
 2. `TAUSCH_CONFIG` environment variable
-3. `$HOME/.config/tausch/config.yml`
+3. `os.UserConfigDir()/tausch/config.yml` (for example `$HOME/.config/tausch/config.yml` on many Unix-like systems)
 
 ### Encoding format for stdout/stderr
 
@@ -168,6 +168,8 @@ Config path is resolved in this order (`internal/flag/values.go:29-42`):
 - `text:<literal text>`
 - `base64:<base64-encoded bytes>`
 - `file:<path to file>`
+
+Relative `file:` paths are resolved from the current working directory of the `tausch` process, not from the config file location.
 
 If the prefix is unknown, decoding fails with `ErrKindNotFound`.
 
@@ -178,7 +180,7 @@ The `exec` package returns an `*exec.Cmd` that actually executes the `tausch` bi
 - It resolves the binary via `exec.LookPath("tausch")`, and falls back to `TAUSCH_PATH` if not found (`exec/exec.go:15-22`).
 - It prefixes arguments with `--` before the real command (`exec/exec.go:24-26`).
 
-Tests in `exec/exec_test.go` rely on the `tausch` binary being present (either via `PATH` including the repo root or via `TAUSCH_PATH`).
+Tests in `exec/exec_test.go` rely on the `tausch` binary being present (either via `PATH` including an absolute repo root or via `TAUSCH_PATH`). Do not rely on `PATH=.`; Go's `exec.LookPath` can reject current-directory matches and cause the wrapper to fall back to `TAUSCH_PATH`.
 
 ## Testing patterns
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Create a config:
 ```yaml
 cmds:
   - name: go version
-    stdout: text:go version go1.26.0 darwin/arm64
+    stdout: "text:go version go1.26.0 darwin/arm64"
   - name: go bob
-    stderr: text:go bob: unknown command
+    stderr: "text:go bob: unknown command"
 ```
 
 Run a command through Tausch:
@@ -117,7 +117,7 @@ The supported kinds are:
 
 - `text:<literal text>` writes the text bytes as-is.
 - `base64:<base64-encoded bytes>` decodes standard base64 and writes the bytes.
-- `file:<path>` reads the file at the path and writes its bytes.
+- `file:<path>` reads the file at the path and writes its bytes. Relative paths are resolved from the current working directory of the `tausch` process, not from the config file location.
 
 The configuration can look like:
 
@@ -164,7 +164,7 @@ The executable reads the config path in this order:
 
 - `-config` - argument with a path.
 - `TAUSCH_CONFIG` - from an env variable.
-- `$HOME/.config/tausch/config.yml` - default config location.
+- The platform user config directory with `tausch/config.yml` appended - default config location. On Unix-like systems this is commonly `$HOME/.config/tausch/config.yml`, but the exact base directory comes from Go's `os.UserConfigDir`.
 
 #### 🧪 exec.CommandContext
 
@@ -172,6 +172,8 @@ Using the library looks for the executable in this order:
 
 - `$PATH` - finds the `tausch` executable provided in the path.
 - `TAUSCH_PATH` - path of the binary if `tausch` is not found on `PATH`.
+
+PATH lookup uses Go's `os/exec.LookPath("tausch")`. If Go rejects a relative current-directory match such as `PATH=.`, the wrapper falls back to `TAUSCH_PATH`; use an absolute directory on `PATH` or set `TAUSCH_PATH` in tests.
 
 ### 💻 Command
 
@@ -214,6 +216,8 @@ _ = cmd.Run()
 ```
 
 The wrapper above invokes the `tausch` binary with `-- go version`, so the command name must be present in the active YAML config.
+
+For library use, configure Tausch with `TAUSCH_CONFIG` or the default config location before running the command. `CommandContext` arguments are only the target command tokens; passing `-config` there would make it part of the stubbed command name instead of a Tausch CLI flag.
 
 ## 🛠️ Development
 

--- a/exec/doc.go
+++ b/exec/doc.go
@@ -19,6 +19,10 @@
 //  1. If `tausch` can be found on PATH via [os/exec.LookPath], that path is used.
 //  2. Otherwise, the value of the `TAUSCH_PATH` environment variable is used.
 //
+// PATH lookup requires [os/exec.LookPath] to return a usable executable path. If
+// Go rejects a relative current-directory match such as PATH=".", this package
+// treats that as unresolved and falls back to `TAUSCH_PATH`.
+//
 // If neither produces a usable path, the returned command will fail when run
 // (for example with an “executable file not found” error).
 //
@@ -26,8 +30,12 @@
 //
 // The tausch CLI discovers its YAML config path via `-config`, `TAUSCH_CONFIG`,
 // or a default location. This package does not set or interpret configuration
-// itself; you are expected to configure tausch via environment variables or
-// CLI flags as appropriate for your application/test.
+// itself; for library use, configure tausch with `TAUSCH_CONFIG` or the default
+// config location before running the returned command.
+//
+// Arguments passed to [CommandContext] are target command tokens only. They are
+// always placed after `--`, so passing `-config` to [CommandContext] would make
+// it part of the stubbed command name instead of a tausch CLI flag.
 //
 // # Example
 //

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -21,9 +21,17 @@ import (
 // This allows command execution to be stubbed by tausch according to its YAML
 // configuration.
 //
+// The provided name and args are target command tokens only. They are always
+// passed after `--`, so tausch CLI flags such as `-config` must be supplied
+// through `TAUSCH_CONFIG` or the default config location instead.
+//
 // Executable resolution follows the tausch CLI wrapper rules:
 //   - Prefer a `tausch` binary found on PATH.
 //   - Otherwise fall back to the `TAUSCH_PATH` environment variable.
+//
+// PATH lookup requires os/exec.LookPath to return a usable executable path. If
+// Go rejects a relative current-directory match such as PATH=".", this function
+// falls back to `TAUSCH_PATH`.
 //
 // If neither provides a usable executable, running the returned command will
 // fail with an underlying exec error (for example “executable file not found”).

--- a/internal/encoding/doc.go
+++ b/internal/encoding/doc.go
@@ -19,7 +19,8 @@
 //
 //   - file:<path>
 //     Interprets data as a filesystem path and returns the contents of the file
-//     via os.ReadFile.
+//     via os.ReadFile. Relative paths are resolved from the current working
+//     directory of the tausch process, not from the config file location.
 //
 //   - base64:<base64-encoded bytes>
 //     Interprets data as a standard base64 encoding (RFC 4648) and decodes it

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -26,6 +26,9 @@ var ErrKindNotFound = errors.New("kind not found")
 //   - "file": treats data as a filesystem path and returns the file contents.
 //   - "base64": treats data as standard base64 and decodes it.
 //
+// Relative "file" paths are resolved from the current working directory of the
+// tausch process, not from the config file location.
+//
 // If the value is missing the ":" separator or kind is unknown, Decode returns
 // ErrKindNotFound.
 //

--- a/internal/io/doc.go
+++ b/internal/io/doc.go
@@ -18,7 +18,8 @@
 //   - If data is the empty string, it performs no writes and returns (false, nil).
 //   - If data is non-empty, it attempts to decode it and write it to w.
 //     On success it returns (true, nil).
-//   - If decoding fails or the underlying write fails, it returns (false, err).
+//   - If decoding fails, it returns (false, err).
+//   - If the underlying write fails after decoding succeeds, it returns (true, err).
 //
 // The returned boolean indicates whether output was attempted/emitted. The CLI
 // orchestration uses this to decide whether to treat a command as a "success"


### PR DESCRIPTION
## What

- Quote the Quick Start YAML payload values so the copied config parses cleanly.
- Clarify config discovery, `file:` path resolution, `CommandContext` setup, and executable lookup edge cases in user-facing docs.
- Align GoDoc for the `exec`, `encoding`, and `io` packages with the runtime contracts covered by tests.

## Why

- Prevent onboarding and test setup failures caused by invalid YAML, platform-specific config path assumptions, cwd-sensitive file payloads, or misplaced `-config` arguments.
- Keep public and maintainer-facing documentation consistent with the code paths that resolve configs, read fixture files, invoke the wrapper binary, and report write attempts.

## Testing

- `ruby -e 'require "yaml"; YAML.safe_load(...)'` - passed
- `gofmt -w exec/doc.go exec/exec.go internal/encoding/doc.go internal/encoding/encoding.go internal/io/doc.go` - passed
- `go test ./internal/flag ./internal/encoding ./internal/cmd ./internal/io` - passed
- `make build` - passed
- `go test ./exec` - passed
- `go test ./...` - passed
- `make lint` - passed
- `./tausch -config test/configs/config.yml -- go version` - passed
