### PR TITLE
docs(readme): show invocation shape in help

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ Tests in `exec/exec_test.go` rely on the `tausch` binary being present (either v
 
 ## CI / release
 
-- CircleCI config: `.circleci/config.yml` runs (in order) `make dep`, `make lint`, `make sec`, `make build`, `make specs`, `make coverage`.
+- CircleCI config: `.circleci/config.yml` wraps the core local validation sequence (`make dep`, `make lint`, `make sec`, `make build`, `make specs`, `make coverage`) with CI setup, cleanup, cache, and upload steps.
 - GoReleaser config: `.goreleaser.yml`.
 
 ## Gotchas

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -19,6 +19,7 @@ func TestRunInvalidArgs(t *testing.T) {
 	require.Empty(t, stdout.Bytes())
 	require.Contains(t, stderr.String(), "flag provided but not defined")
 	require.Contains(t, stderr.String(), "Usage of tausch:")
+	require.Contains(t, stderr.String(), "tausch [flags] -- <command tokens...>")
 }
 
 func TestRunConfigError(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,8 +31,8 @@ var ErrMultipleOutputs = errors.New("multiple outputs configured")
 //
 // The returned *Config is ready to be queried with [Config.GetCommand].
 //
-// Errors are returned for I/O failures (opening/reading the file) and for YAML
-// decoding errors.
+// Errors are returned for I/O failures (opening/reading the file), YAML decoding
+// errors, and validation failures such as [ErrMultipleOutputs].
 func Decode(path string) (*Config, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/flag/values.go
+++ b/internal/flag/values.go
@@ -2,6 +2,7 @@ package flag
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -23,6 +24,16 @@ import (
 func Parse(output io.Writer, args []string) (*Values, error) {
 	set := flag.NewFlagSet("tausch", flag.ContinueOnError)
 	set.SetOutput(output)
+	set.Usage = func() {
+		fmt.Fprintln(set.Output(), "Usage of tausch:")
+		fmt.Fprintln(set.Output(), "  tausch [flags] -- <command tokens...>")
+		fmt.Fprintln(set.Output())
+		fmt.Fprintln(set.Output(), "Command tokens after -- are joined with spaces")
+		fmt.Fprintln(set.Output(), "and matched against a config entry's name.")
+		fmt.Fprintln(set.Output())
+		fmt.Fprintln(set.Output(), "Flags:")
+		set.PrintDefaults()
+	}
 
 	file := set.String("config", "", "the config file path")
 	if err := set.Parse(args); err != nil {


### PR DESCRIPTION
## What

- Add CLI help output that shows the required `-- <command tokens...>` invocation shape and explains how command tokens map to config names.
- Extend the invalid-argument test to cover the documented usage line.
- Clarify that `config.Decode` can return validation errors such as `ErrMultipleOutputs`.
- Clarify the AGENTS CI summary as core local validation wrapped by CI setup, cleanup, cache, and upload steps.

## Why

- The default flag help only listed `-config`, which left users without command-line guidance for passing the stubbed command.
- The decode GoDoc omitted one error path that maintainers already rely on in tests.
- The maintainer CI note implied an exact CircleCI sequence while omitting CI-only wrapper steps.

## Testing

- `make build` - passed
- `go test ./...` - passed
- `make lint` - passed with the existing gomodguard deprecation warning from golangci-lint configuration
- `go run . -h` - printed the updated usage text; it still exits 1 through the existing help handling path

AI-assisted-by: [Codex](https://openai.com/codex/)
