### PR TITLE
build(project): make specs compile cli first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ include bin/build/make/git.mak
 # Build the cli.
 build:
 	@go build
+
+# Run specs after building the cli.
+specs: build


### PR DESCRIPTION
## What

- Make the root `specs` target depend on the CLI build target.
- Preserve the shared Go test recipe for the actual test execution.

## Why

- The test suite exercises the `./tausch` binary, so local specs needed callers to remember to build first.
- Encoding the prerequisite makes the advertised validation entrypoint self-contained and matches the CI ordering.

## Testing

- `gmake -n specs` - passed and shows `go build` before the shared Go test wrapper.
- `gmake specs` - passed.
