### PR TITLE
feat(exec): add context-free command helper

### DIFF
--- a/exec/doc.go
+++ b/exec/doc.go
@@ -8,9 +8,9 @@
 // binary so that stdout/stderr and exit codes can be stubbed based on a
 // tausch YAML configuration.
 //
-// Concretely, [CommandContext] creates an [os/exec.Cmd] whose executable is
-// the `tausch` binary and whose arguments are prefixed with `--`, followed by
-// the command you want to run.
+// Concretely, [Command] and [CommandContext] create an [os/exec.Cmd] whose
+// executable is the `tausch` binary and whose arguments are prefixed with `--`,
+// followed by the command you want to run.
 //
 // # Executable resolution
 //
@@ -33,13 +33,14 @@
 // itself; for library use, configure tausch with `TAUSCH_CONFIG` or the default
 // config location before running the returned command.
 //
-// Arguments passed to [CommandContext] are target command tokens only. They are
-// always placed after `--`, so passing `-config` to [CommandContext] would make
-// it part of the stubbed command name instead of a tausch CLI flag.
+// Arguments passed to [Command] or [CommandContext] are target command tokens
+// only. They are always placed after `--`, so passing `-config` to either
+// function would make it part of the stubbed command name instead of a tausch
+// CLI flag.
 //
 // # Example
 //
-//	cmd := exec.CommandContext(ctx, "go", "version")
+//	cmd := exec.Command("go", "version")
 //	out, err := cmd.CombinedOutput()
 //
 // This will execute something equivalent to:

--- a/exec/example_test.go
+++ b/exec/example_test.go
@@ -1,0 +1,89 @@
+package exec_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/alexfalkowski/tausch/exec"
+)
+
+func ExampleCommand() {
+	cleanup, err := setupExampleTausch()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanup()
+
+	out, err := exec.Command("go", "version").Output()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Print(string(out))
+	// Output:
+	// -- go version
+}
+
+func ExampleCommandContext() {
+	cleanup, err := setupExampleTausch()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanup()
+
+	out, err := exec.CommandContext(context.Background(), "go", "version").Output()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Print(string(out))
+	// Output:
+	// -- go version
+}
+
+func setupExampleTausch() (func(), error) {
+	dir, err := os.MkdirTemp("", "tausch-example")
+	if err != nil {
+		return nil, err
+	}
+
+	cleanup := func() {
+		os.RemoveAll(dir)
+	}
+
+	tausch := filepath.Join(dir, "tausch")
+	if err := os.WriteFile(tausch, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\"\n"), 0o600); err != nil {
+		cleanup()
+		return nil, err
+	}
+	if err := os.Chmod(tausch, 0o700); err != nil {
+		cleanup()
+		return nil, err
+	}
+
+	oldPath := os.Getenv("PATH")
+	oldConfig, hadConfig := os.LookupEnv("TAUSCH_CONFIG")
+	os.Setenv("PATH", dir)
+	os.Setenv("TAUSCH_CONFIG", "config.yml")
+
+	return func() {
+		os.Setenv("PATH", oldPath)
+		restoreEnv("TAUSCH_CONFIG", oldConfig, hadConfig)
+		cleanup()
+	}, nil
+}
+
+func restoreEnv(key, value string, hadValue bool) {
+	if hadValue {
+		os.Setenv(key, value)
+		return
+	}
+
+	os.Unsetenv(key)
+}

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -6,6 +6,25 @@ import (
 	"os/exec"
 )
 
+// Command returns an [exec.Cmd] that runs the given command through the
+// `tausch` CLI.
+//
+// It mirrors [os/exec.Command] for callers that do not need context
+// cancellation. The returned command executes the `tausch` binary and prefixes
+// the provided command with `--`, so this:
+//
+//	exec.Command("go", "version")
+//
+// results in an invocation equivalent to:
+//
+//	tausch -- go version
+//
+// Tausch CLI flags such as `-config` must be supplied through `TAUSCH_CONFIG` or
+// the default config location instead of through name or arg.
+func Command(name string, arg ...string) *exec.Cmd {
+	return exec.Command(executable(), commandArgs(name, arg...)...) //nolint:noctx // Mirrors os/exec.Command.
+}
+
 // CommandContext returns an [exec.Cmd] that runs the given command through the
 // `tausch` CLI.
 //

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -2,8 +2,6 @@ package exec_test
 
 import (
 	"bytes"
-	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,6 +21,24 @@ func TestPathCommandSuccess(t *testing.T) {
 	stderr := &bytes.Buffer{}
 
 	cmd := exec.CommandContext(t.Context(), "go", "version")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	require.NoError(t, cmd.Run())
+	require.NoError(t, cmd.Err)
+	require.Equal(t, readFixture(t, "../test/stdout/go_version.txt"), stdout.Bytes())
+	require.Empty(t, stderr.Bytes())
+}
+
+func TestCommandSuccess(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("TAUSCH_PATH", "../tausch")
+	t.Setenv("TAUSCH_CONFIG", "../test/configs/exec.yml")
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := exec.Command("go", "version")
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
@@ -147,43 +163,6 @@ func TestCommandError(t *testing.T) {
 	require.Equal(t, readFixture(t, "../test/stderr/go_bob.txt"), stderr.Bytes())
 }
 
-func ExampleCommandContext() {
-	dir, err := os.MkdirTemp("", "tausch-example")
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	defer os.RemoveAll(dir)
-
-	tausch := filepath.Join(dir, "tausch")
-	if err := os.WriteFile(tausch, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\"\n"), 0o600); err != nil {
-		fmt.Println(err)
-		return
-	}
-	if err := os.Chmod(tausch, 0o700); err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	oldPath := os.Getenv("PATH")
-	os.Setenv("PATH", dir)
-	defer os.Setenv("PATH", oldPath)
-
-	oldConfig, hadConfig := os.LookupEnv("TAUSCH_CONFIG")
-	os.Setenv("TAUSCH_CONFIG", "config.yml")
-	defer restoreEnv("TAUSCH_CONFIG", oldConfig, hadConfig)
-
-	out, err := exec.CommandContext(context.Background(), "go", "version").Output()
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	fmt.Print(string(out))
-	// Output:
-	// -- go version
-}
-
 func readFixture(t *testing.T, path string) []byte {
 	t.Helper()
 
@@ -198,13 +177,4 @@ func writeExecutable(t *testing.T, path, script string) {
 
 	require.NoError(t, os.WriteFile(path, []byte(script), 0o600))
 	require.NoError(t, os.Chmod(path, 0o700))
-}
-
-func restoreEnv(key, value string, hadValue bool) {
-	if hadValue {
-		os.Setenv(key, value)
-		return
-	}
-
-	os.Unsetenv(key)
 }


### PR DESCRIPTION
## What

- Add a context-free `Command` helper to the Go wrapper package so callers can construct tausch-backed commands without providing a context.
- Keep the existing `CommandContext` path unchanged and route both helpers through the same tausch executable resolution and `--` argument handling.
- Update package GoDoc and executable examples to show both public call shapes, with examples split into `example_test.go`.

## Why

- This lets package consumers adopt the wrapper from call sites shaped like `os/exec.Command` without first changing those call sites to thread a context.
- The new helper is additive, so existing `CommandContext` users and CLI behavior keep their current contracts.

## Testing

- `make build` - passed
- `go test ./...` - passed
- `make lint` - passed
- `make sec` - passed
- `make specs` - passed
- Added package-level coverage for `Command` and executable examples for both public wrapper helpers.
