### PR TITLE
feat(config): support explicit command exit status

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ tausch -config config.yml -- go version
 
 ## ⚙️ Configuration
 
-The configuration is a YAML document with a top-level `cmds` list. Each command entry has a `name` and may set `stdout` or `stderr`.
+The configuration is a YAML document with a top-level `cmds` list. Each command entry has a `name` and may set `stdout`, `stderr`, or `exit_code`.
 
 The `stdout` and `stderr` values use a `kind:data` format:
 
@@ -129,10 +129,13 @@ cmds:
     stdout: file:test/stdout/go_version.txt
   - name: go bob
     stderr: file:test/stderr/go_bob.txt
+    exit_code: 127
+  - name: grep needle file.txt
+    exit_code: 1
 ```
 
 > [!IMPORTANT]
-> Configure exactly one non-empty encoded output stream for each useful stub. A non-empty `stdout` value is treated as successful and exits `0`; if `stdout` is empty or omitted, Tausch falls back to `stderr` and exits `1`. If both streams are empty or omitted, the command exits `1` with no configured output. To stub a successful command that writes zero bytes, use `stdout: "text:"`. Configuring both `stdout` and `stderr` for one command is rejected.
+> Configure at most one non-empty encoded output stream for each stub. By default, a non-empty `stdout` value exits `0`; otherwise, Tausch falls back to `stderr` and exits `1`. If both streams are empty or omitted, the command exits `1` with no configured output. Set `exit_code` to override the default after output is written successfully; valid values are `0` through `255`. To stub a successful command that writes zero bytes, use `stdout: "text:"`. Configuring both `stdout` and `stderr` for one command is rejected.
 
 Payload values and `file:` paths are decoded only when the matching command is invoked, not when the YAML file is loaded.
 

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -163,6 +163,27 @@ func TestCommandError(t *testing.T) {
 	require.Equal(t, readFixture(t, "../test/stderr/go_bob.txt"), stderr.Bytes())
 }
 
+func TestCommandErrorExitCode(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("TAUSCH_PATH", "../tausch")
+	t.Setenv("TAUSCH_CONFIG", "../test/configs/exec_exit_code.yml")
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := exec.CommandContext(t.Context(), "go", "bob")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err := cmd.Run()
+	require.Error(t, err)
+	require.NoError(t, cmd.Err)
+	require.NotNil(t, cmd.ProcessState)
+	require.Equal(t, 127, cmd.ProcessState.ExitCode())
+	require.Empty(t, stdout.Bytes())
+	require.Equal(t, readFixture(t, "../test/stderr/go_bob.txt"), stderr.Bytes())
+}
+
 func readFixture(t *testing.T, path string) []byte {
 	t.Helper()
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -33,8 +33,10 @@ import (
 //     stderr and Run returns 1.
 //   - If config resolution, config decoding, command lookup, or stdout/stderr
 //     decode/write steps fail, Run writes the error to stderr and returns 1.
-//   - If the command's configured `stdout` is non-empty and is successfully
-//     written, Run returns 0.
+//   - If the configured command has `exit_code`, Run returns that code after
+//     successfully writing the configured output.
+//   - Without `exit_code`, if the command's configured `stdout` is non-empty and
+//     successfully written, Run returns 0.
 //   - Otherwise, Run writes the configured `stderr` payload and returns 1. If
 //     both payloads are empty, Run returns 1 with no configured output.
 //
@@ -72,13 +74,22 @@ func Run(stdout, stderr io.Writer, args []string) int {
 	}
 
 	if wroteStdout {
-		return 0
+		return exitCode(command, 0)
 	}
 
 	_, err = io.Write(stderr, command.Stderr)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
+		return 1
 	}
 
-	return 1
+	return exitCode(command, 1)
+}
+
+func exitCode(command *config.Command, defaultCode int) int {
+	if command.ExitCode == nil {
+		return defaultCode
+	}
+
+	return *command.ExitCode
 }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -128,6 +128,23 @@ func TestRunStdout(t *testing.T) {
 	require.Empty(t, stderr.Bytes())
 }
 
+func TestRunStdoutExitCode(t *testing.T) {
+	t.Chdir("../..")
+
+	args := []string{
+		"-config", "test/configs/exit_code.yml",
+		"--",
+		"go", "version",
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := cmd.Run(stdout, stderr, args)
+
+	require.Equal(t, 7, code)
+	require.NotEmpty(t, stdout.Bytes())
+	require.Empty(t, stderr.Bytes())
+}
+
 func TestRunStderrWriteError(t *testing.T) {
 	args := []string{
 		"-config", "../../test/configs/stderr_invalid_base64.yml",
@@ -158,4 +175,36 @@ func TestRunStderr(t *testing.T) {
 	require.Equal(t, 1, code)
 	require.Empty(t, stdout.Bytes())
 	require.NotEmpty(t, stderr.Bytes())
+}
+
+func TestRunStderrExitCode(t *testing.T) {
+	t.Chdir("../..")
+
+	args := []string{
+		"-config", "test/configs/exit_code.yml",
+		"--",
+		"go", "bob",
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := cmd.Run(stdout, stderr, args)
+
+	require.Equal(t, 127, code)
+	require.Empty(t, stdout.Bytes())
+	require.NotEmpty(t, stderr.Bytes())
+}
+
+func TestRunNoOutputExitCode(t *testing.T) {
+	args := []string{
+		"-config", "../../test/configs/exit_code.yml",
+		"--",
+		"grep", "needle", "file.txt",
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := cmd.Run(stdout, stderr, args)
+
+	require.Equal(t, 1, code)
+	require.Empty(t, stdout.Bytes())
+	require.Empty(t, stderr.Bytes())
 }

--- a/internal/cmd/doc.go
+++ b/internal/cmd/doc.go
@@ -34,8 +34,10 @@
 //
 // In normal operation:
 //
-//   - If the configured command's `stdout` value is non-empty and successfully
-//     written, [Run] returns exit code 0.
+//   - If the configured command has `exit_code`, [Run] returns that code after
+//     successfully writing the configured output.
+//   - Without `exit_code`, if the configured command's `stdout` value is
+//     non-empty and successfully written, [Run] returns exit code 0.
 //   - Otherwise, it attempts to write the configured `stderr` value and returns
 //     exit code 1. If both values are empty, it returns exit code 1 with no
 //     configured output.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,11 +16,18 @@ import (
 var ErrCommandNotFound = errors.New("command not found")
 
 // ErrMultipleOutputs is returned when a command configures both stdout and
-// stderr. A command stub must choose one output stream because stdout indicates
-// success and stderr indicates failure.
+// stderr. A command stub can emit one configured output stream.
 //
 // Callers typically compare with errors.Is(err, ErrMultipleOutputs).
 var ErrMultipleOutputs = errors.New("multiple outputs configured")
+
+// ErrInvalidExitCode is returned when a command configures an exit code outside
+// the supported process exit status range.
+//
+// Callers typically compare with errors.Is(err, ErrInvalidExitCode).
+var ErrInvalidExitCode = errors.New("invalid exit code")
+
+const maxExitCode = 255
 
 // Decode reads a YAML configuration file from path and decodes it into a [Config].
 //
@@ -32,7 +39,8 @@ var ErrMultipleOutputs = errors.New("multiple outputs configured")
 // The returned *Config is ready to be queried with [Config.GetCommand].
 //
 // Errors are returned for I/O failures (opening/reading the file), YAML decoding
-// errors, and validation failures such as [ErrMultipleOutputs].
+// errors, and validation failures such as [ErrMultipleOutputs] or
+// [ErrInvalidExitCode].
 func Decode(path string) (*Config, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -67,7 +75,8 @@ type Config struct {
 // Validate checks command-level config invariants.
 //
 // It permits nil command entries so lookup remains tolerant of sparse decoded
-// data, but non-nil commands must not configure both stdout and stderr.
+// data, but non-nil commands must not configure both stdout and stderr and must
+// keep exit codes in range.
 func (c *Config) Validate() error {
 	for _, command := range c.Cmds {
 		if command == nil {
@@ -76,6 +85,10 @@ func (c *Config) Validate() error {
 
 		if command.hasMultipleOutputs() {
 			return fmt.Errorf("command %q: %w", command.Name, ErrMultipleOutputs)
+		}
+
+		if command.hasInvalidExitCode() {
+			return fmt.Errorf("command %q: %w", command.Name, ErrInvalidExitCode)
 		}
 	}
 
@@ -104,24 +117,31 @@ func (c *Config) GetCommand(name string) (*Command, error) {
 
 // Command is a single command stub entry in the configuration.
 //
-// Name identifies the command to match (as derived by the CLI), and Stdout/Stderr
-// define what tausch should emit when that command is invoked.
+// Name identifies the command to match (as derived by the CLI), Stdout/Stderr
+// define what tausch should emit when that command is invoked, and ExitCode can
+// override the default process exit code.
 //
 // Stdout and Stderr are strings using tausch's `kind:data` format. Supported kinds
 // are decoded by internal/io (for example `text:...`, `file:...`, `base64:...`).
 type Command struct {
+	// ExitCode is the optional process exit code to return after successfully
+	// writing the configured output.
+	ExitCode *int `yaml:"exit_code"`
+
 	// Name is the exact command name to match (for example "go version").
 	Name string `yaml:"name"`
 
-	// Stdout is the encoded payload to write to stdout when the command is treated
-	// as successful (non-empty value).
+	// Stdout is the encoded payload to write to stdout.
 	Stdout string `yaml:"stdout"`
 
-	// Stderr is the encoded payload to write to stderr when stdout is empty and the
-	// command is treated as failing.
+	// Stderr is the encoded payload to write to stderr when stdout is empty.
 	Stderr string `yaml:"stderr"`
 }
 
 func (c *Command) hasMultipleOutputs() bool {
 	return c.Stdout != "" && c.Stderr != ""
+}
+
+func (c *Command) hasInvalidExitCode() bool {
+	return c.ExitCode != nil && (*c.ExitCode < 0 || *c.ExitCode > maxExitCode)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,15 @@ func TestDecodeSuccess(t *testing.T) {
 	require.NotNil(t, c)
 }
 
+func TestDecodeExitCode(t *testing.T) {
+	c, err := config.Decode("../../test/configs/exit_code.yml")
+
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	require.NotNil(t, c.Cmds[0].ExitCode)
+	require.Equal(t, 7, *c.Cmds[0].ExitCode)
+}
+
 func TestDecodeError(t *testing.T) {
 	values := []string{
 		"../../test/configs/none.yml",
@@ -36,6 +45,14 @@ func TestDecodeMultipleOutputs(t *testing.T) {
 	require.Nil(t, c)
 	require.ErrorIs(t, err, config.ErrMultipleOutputs)
 	require.Contains(t, err.Error(), `command "go version"`)
+}
+
+func TestDecodeInvalidExitCode(t *testing.T) {
+	c, err := config.Decode("../../test/configs/invalid_exit_code.yml")
+
+	require.Nil(t, c)
+	require.ErrorIs(t, err, config.ErrInvalidExitCode)
+	require.Contains(t, err.Error(), `command "go bob"`)
 }
 
 func TestGetCommandNilCommand(t *testing.T) {

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -14,12 +14,18 @@
 //	cmds:
 //	  - name: "go version"
 //	    stdout: "text:go version go1.25.0 darwin/arm64\n"
-//	    stderr: ""
+//	    exit_code: 0
+//	  - name: "grep needle file.txt"
+//	    exit_code: 1
 //
-// # Stdout/stderr payload encoding
+// # Output and exit status
 //
-// The `stdout` and `stderr` fields are strings that are interpreted elsewhere
-// (see internal/io). They use a `kind:data` format such as:
+// Each command can configure at most one non-empty `stdout` or `stderr` payload.
+// The optional `exit_code` field overrides the CLI's default exit status and
+// must be between 0 and 255.
+//
+// The `stdout` and `stderr` fields are strings interpreted elsewhere (see
+// internal/io). They use a `kind:data` format such as:
 //
 //   - text:<literal text>
 //   - base64:<base64-encoded bytes>

--- a/internal/io/doc.go
+++ b/internal/io/doc.go
@@ -23,8 +23,8 @@
 //     (true, err).
 //
 // The returned boolean indicates whether output was attempted/emitted. The CLI
-// orchestration uses this to decide whether to treat a command as a "success"
-// path (stdout present) or "error" path (fallback to stderr + non-zero exit).
+// orchestration uses this to choose between stdout and the fallback stderr path;
+// configured exit status is handled outside this package.
 //
 // # Writer alias
 //

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -28,8 +28,8 @@ type Writer = io.Writer
 // decoded before being copied to w. On successful output, Write returns (true, nil).
 //
 // The returned boolean indicates whether output was attempted/emitted. This is used
-// by the CLI orchestration to decide whether a command should be treated as having
-// produced stdout (success path) or should fall back to stderr (error path).
+// by the CLI orchestration to decide whether stdout was produced or whether it
+// should fall back to stderr.
 //
 // Errors from decoding or from the underlying writer are returned.
 func Write(w io.Writer, data string) (bool, error) {

--- a/test/configs/exec_exit_code.yml
+++ b/test/configs/exec_exit_code.yml
@@ -1,0 +1,4 @@
+cmds:
+  - name: go bob
+    stderr: file:../test/stderr/go_bob.txt
+    exit_code: 127

--- a/test/configs/exit_code.yml
+++ b/test/configs/exit_code.yml
@@ -1,0 +1,9 @@
+cmds:
+  - name: go version
+    stdout: file:test/stdout/go_version.txt
+    exit_code: 7
+  - name: go bob
+    stderr: file:test/stderr/go_bob.txt
+    exit_code: 127
+  - name: grep needle file.txt
+    exit_code: 1

--- a/test/configs/invalid_exit_code.yml
+++ b/test/configs/invalid_exit_code.yml
@@ -1,0 +1,4 @@
+cmds:
+  - name: go bob
+    stderr: text:go bob
+    exit_code: 256


### PR DESCRIPTION
## What

- Add an optional command-level `exit_code` config field for stubs that need a process status other than the stdout/stderr defaults.
- Preserve existing output behavior: stubs still configure at most one non-empty output stream, stdout defaults to exit 0, and stderr or no output defaults to exit 1.
- Validate configured exit codes as process status values from 0 through 255, and document the new field in README and package docs.
- Add config, CLI, and exec package tests plus YAML fixtures that cover stdout, stderr, no-output, invalid, and spawned-process exit-code behavior.

## Why

- Test authors sometimes need to model command outcomes like `grep` returning 1 with no output or tools returning a specific non-zero status on stderr. The previous hard-coded 0/1 behavior made those command stubs less faithful than the real process behavior they replace.
- The change is additive and keeps existing configs compatible while making the command result model precise enough for common subprocess test cases.

## Testing

- `make lint` - passed
- `make sec` - passed
- `go test ./...` - passed
- `make build` - passed
- `make specs` - passed
- `make coverage` - passed, 99.1% statements

AI-assisted-by: [Codex](https://openai.com/codex/)
