### PR TITLE
feat(config): resolve file payloads from yaml location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ Config path is resolved in this order (`internal/flag/values.go:29-42`):
 - `base64:<base64-encoded bytes>`
 - `file:<path to file>`
 
-Relative `file:` paths are resolved from the current working directory of the `tausch` process, not from the config file location.
+Relative `file:` paths are resolved from the directory containing the config file.
 
 If the prefix is unknown, decoding fails with `ErrKindNotFound`.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The supported kinds are:
 
 - `text:<literal text>` writes the text bytes as-is.
 - `base64:<base64-encoded bytes>` decodes standard base64 and writes the bytes.
-- `file:<path>` reads the file at the path and writes its bytes. Relative paths are resolved from the current working directory of the `tausch` process, not from the config file location.
+- `file:<path>` reads the file at the path and writes its bytes. Relative paths are resolved from the directory containing the config file.
 
 The configuration can look like:
 

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -15,7 +15,7 @@ func TestPathCommandSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Setenv("PATH", root)
-	t.Setenv("TAUSCH_CONFIG", "../test/configs/exec.yml")
+	t.Setenv("TAUSCH_CONFIG", "../test/configs/config.yml")
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -33,7 +33,7 @@ func TestPathCommandSuccess(t *testing.T) {
 func TestCommandSuccess(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	t.Setenv("TAUSCH_PATH", "../tausch")
-	t.Setenv("TAUSCH_CONFIG", "../test/configs/exec.yml")
+	t.Setenv("TAUSCH_CONFIG", "../test/configs/config.yml")
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -73,7 +73,7 @@ func TestCommandPrefersPathOverTauschPath(t *testing.T) {
 func TestCommandFallsBackToTauschPath(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	t.Setenv("TAUSCH_PATH", "../tausch")
-	t.Setenv("TAUSCH_CONFIG", "../test/configs/exec.yml")
+	t.Setenv("TAUSCH_CONFIG", "../test/configs/config.yml")
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -145,7 +145,7 @@ func TestCommandPassesVariadicArgs(t *testing.T) {
 func TestCommandError(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	t.Setenv("TAUSCH_PATH", "../tausch")
-	t.Setenv("TAUSCH_CONFIG", "../test/configs/exec.yml")
+	t.Setenv("TAUSCH_CONFIG", "../test/configs/config.yml")
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -166,7 +166,7 @@ func TestCommandError(t *testing.T) {
 func TestCommandErrorExitCode(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	t.Setenv("TAUSCH_PATH", "../tausch")
-	t.Setenv("TAUSCH_CONFIG", "../test/configs/exec_exit_code.yml")
+	t.Setenv("TAUSCH_CONFIG", "../test/configs/exit_code.yml")
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -19,7 +19,8 @@ import (
 //  4. Derives the command name (via (*flag.Values).Name) and looks up the
 //     matching command entry (via (*config.Config).GetCommand).
 //  5. Writes the configured `stdout` payload to stdout if non-empty; otherwise
-//     it writes the configured `stderr` payload to stderr (via internal/io.Write).
+//     it writes the configured `stderr` payload to stderr (via internal/io.Write),
+//     resolving relative file payloads from the config file directory.
 //
 // The configured stdout/stderr payloads are strings in tausch's `kind:data`
 // format (for example `text:...`, `file:...`, `base64:...`) and are decoded by
@@ -67,7 +68,7 @@ func Run(stdout, stderr io.Writer, args []string) int {
 		return 1
 	}
 
-	wroteStdout, err := io.Write(stdout, command.Stdout)
+	wroteStdout, err := io.Write(stdout, command.Stdout, cfg.Dir)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
@@ -77,7 +78,7 @@ func Run(stdout, stderr io.Writer, args []string) int {
 		return exitCode(command, 0)
 	}
 
-	_, err = io.Write(stderr, command.Stderr)
+	_, err = io.Write(stderr, command.Stderr, cfg.Dir)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1

--- a/internal/cmd/doc.go
+++ b/internal/cmd/doc.go
@@ -11,7 +11,8 @@
 //   - Resolve the tausch YAML config path (delegated to internal/flag).
 //   - Decode the YAML configuration (delegated to internal/config).
 //   - Look up the command entry by name (delegated to internal/config).
-//   - Decode and write configured stdout/stderr payloads (delegated to internal/io).
+//   - Decode and write configured stdout/stderr payloads relative to the config
+//     file directory (delegated to internal/io).
 //   - Return an exit status code that the CLI can use as its process exit code.
 //
 // # Command name matching

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 
 	"go.yaml.in/yaml/v3"
@@ -34,7 +35,8 @@ const maxExitCode = 255
 // The YAML is expected to match the tausch schema (a top-level `cmds` list). This
 // function validates command-level invariants, but it does not validate that any
 // commands are present or that stdout/stderr payload strings are valid
-// `kind:data` values.
+// `kind:data` values. The decoded config records the absolute directory of path
+// so relative file payloads can be resolved from the config file location.
 //
 // The returned *Config is ready to be queried with [Config.GetCommand].
 //
@@ -42,13 +44,20 @@ const maxExitCode = 255
 // errors, and validation failures such as [ErrMultipleOutputs] or
 // [ErrInvalidExitCode].
 func Decode(path string) (*Config, error) {
-	f, err := os.Open(path)
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(abs)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 
 	var config Config
+	config.Dir = filepath.Dir(abs)
+
 	if err := yaml.NewDecoder(f).Decode(&config); err != nil {
 		return nil, err
 	}
@@ -68,6 +77,9 @@ func Decode(path string) (*Config, error) {
 // The stdout/stderr fields inside each command are stored as opaque strings here;
 // decoding those values into bytes is handled by internal/io.
 type Config struct {
+	// Dir is the absolute directory containing the decoded YAML config file.
+	Dir string `yaml:"-"`
+
 	// Cmds is the set of configured command stubs.
 	Cmds []*Command `yaml:"cmds"`
 }

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -32,7 +32,8 @@
 //   - file:<path to a file whose bytes should be written>
 //
 // This package treats those fields as opaque strings; it does not decode or
-// validate the `kind:data` format.
+// validate the `kind:data` format. It records the config file directory so the
+// CLI can resolve relative `file:` payloads from the config location.
 //
 // # Command lookup
 //

--- a/internal/io/doc.go
+++ b/internal/io/doc.go
@@ -9,7 +9,8 @@
 // The tausch YAML config stores `stdout` and `stderr` as strings in a
 // `kind:data` format (for example `text:hello`, `file:/tmp/out.txt`,
 // `base64:...`). This package decodes those payloads and copies the resulting
-// stream to the supplied writer.
+// stream to the supplied writer. Relative `file:` paths are resolved from the
+// config file directory supplied by the caller.
 //
 // # Write semantics
 //

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -25,19 +26,20 @@ type Writer = io.Writer
 // If data is the empty string, Write performs no writes and returns (false, nil).
 //
 // If data is non-empty, it is expected to be in tausch's `kind:data` format and
-// decoded before being copied to w. On successful output, Write returns (true, nil).
+// decoded before being copied to w. Relative file payloads are resolved from dir.
+// On successful output, Write returns (true, nil).
 //
 // The returned boolean indicates whether output was attempted/emitted. This is used
 // by the CLI orchestration to decide whether stdout was produced or whether it
 // should fall back to stderr.
 //
 // Errors from decoding or from the underlying writer are returned.
-func Write(w io.Writer, data string) (bool, error) {
+func Write(w io.Writer, data, dir string) (bool, error) {
 	if data == "" {
 		return false, nil
 	}
 
-	r, err := decode(data)
+	r, err := decode(data, dir)
 	if err != nil {
 		return false, err
 	}
@@ -47,7 +49,7 @@ func Write(w io.Writer, data string) (bool, error) {
 	return true, err
 }
 
-func decode(value string) (io.ReadCloser, error) {
+func decode(value, dir string) (io.ReadCloser, error) {
 	kind, data, ok := strings.Cut(value, ":")
 	if !ok {
 		return nil, ErrKindNotFound
@@ -57,7 +59,7 @@ func decode(value string) (io.ReadCloser, error) {
 	case "text":
 		return io.NopCloser(strings.NewReader(data)), nil
 	case "file":
-		return os.Open(data)
+		return os.Open(filePath(data, dir))
 	case "base64":
 		d, err := base64.StdEncoding.DecodeString(data)
 		if err != nil {
@@ -68,4 +70,12 @@ func decode(value string) (io.ReadCloser, error) {
 	}
 
 	return nil, ErrKindNotFound
+}
+
+func filePath(path, dir string) string {
+	if dir == "" || filepath.IsAbs(path) {
+		return path
+	}
+
+	return filepath.Join(dir, path)
 }

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -17,18 +17,20 @@ func TestWriteSuccess(t *testing.T) {
 	require.NoError(t, os.WriteFile(file, want, 0o600))
 
 	values := []struct {
+		dir   string
 		name  string
 		value string
 	}{
 		{name: "text", value: "text: test\n"},
 		{name: "base64", value: "base64:IHRlc3QK"},
-		{name: "file", value: "file:" + file},
+		{name: "file absolute", value: "file:" + file},
+		{dir: filepath.Dir(file), name: "file relative", value: "file:" + filepath.Base(file)},
 	}
 
 	for _, tt := range values {
 		t.Run(tt.name, func(t *testing.T) {
 			buffer := &bytes.Buffer{}
-			wrote, err := io.Write(buffer, tt.value)
+			wrote, err := io.Write(buffer, tt.value, tt.dir)
 
 			require.NoError(t, err)
 			require.True(t, wrote)
@@ -46,7 +48,7 @@ func TestWriteError(t *testing.T) {
 	for _, value := range values {
 		t.Run(value, func(t *testing.T) {
 			buffer := &bytes.Buffer{}
-			wrote, err := io.Write(buffer, value)
+			wrote, err := io.Write(buffer, value, "")
 
 			require.Error(t, err)
 			require.False(t, wrote)
@@ -66,7 +68,7 @@ func TestWriteKindNotFound(t *testing.T) {
 	for _, value := range values {
 		t.Run(value, func(t *testing.T) {
 			buffer := &bytes.Buffer{}
-			wrote, err := io.Write(buffer, value)
+			wrote, err := io.Write(buffer, value, "")
 
 			require.ErrorIs(t, err, io.ErrKindNotFound)
 			require.False(t, wrote)
@@ -77,7 +79,7 @@ func TestWriteKindNotFound(t *testing.T) {
 
 func TestWritePreservesDataAfterFirstColon(t *testing.T) {
 	buffer := &bytes.Buffer{}
-	wrote, err := io.Write(buffer, "text:a:b")
+	wrote, err := io.Write(buffer, "text:a:b", "")
 
 	require.NoError(t, err)
 	require.True(t, wrote)
@@ -86,7 +88,7 @@ func TestWritePreservesDataAfterFirstColon(t *testing.T) {
 
 func TestWriteEmpty(t *testing.T) {
 	buffer := &bytes.Buffer{}
-	wrote, err := io.Write(buffer, "")
+	wrote, err := io.Write(buffer, "", "")
 
 	require.NoError(t, err)
 	require.False(t, wrote)
@@ -94,7 +96,7 @@ func TestWriteEmpty(t *testing.T) {
 }
 
 func TestWriteWriterError(t *testing.T) {
-	wrote, err := io.Write(test.FailingWriter{}, "text:test")
+	wrote, err := io.Write(test.FailingWriter{}, "text:test", "")
 
 	require.ErrorIs(t, err, test.ErrWriteFailed)
 	require.True(t, wrote)

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -1,5 +1,5 @@
 cmds:
   - name: go version
-    stdout: file:test/stdout/go_version.txt
+    stdout: file:../stdout/go_version.txt
   - name: go bob
-    stderr: file:test/stderr/go_bob.txt
+    stderr: file:../stderr/go_bob.txt

--- a/test/configs/exec.yml
+++ b/test/configs/exec.yml
@@ -1,5 +1,0 @@
-cmds:
-  - name: go version
-    stdout: file:../test/stdout/go_version.txt
-  - name: go bob
-    stderr: file:../test/stderr/go_bob.txt

--- a/test/configs/exec_exit_code.yml
+++ b/test/configs/exec_exit_code.yml
@@ -1,4 +1,0 @@
-cmds:
-  - name: go bob
-    stderr: file:../test/stderr/go_bob.txt
-    exit_code: 127

--- a/test/configs/exit_code.yml
+++ b/test/configs/exit_code.yml
@@ -1,9 +1,9 @@
 cmds:
   - name: go version
-    stdout: file:test/stdout/go_version.txt
+    stdout: file:../stdout/go_version.txt
     exit_code: 7
   - name: go bob
-    stderr: file:test/stderr/go_bob.txt
+    stderr: file:../stderr/go_bob.txt
     exit_code: 127
   - name: grep needle file.txt
     exit_code: 1


### PR DESCRIPTION
## What

- Resolve relative `file:` payload paths from the directory containing the YAML config file instead of from the process working directory.
- Keep absolute `file:` paths, `text:`, `base64:`, output defaults, and `exit_code` behavior unchanged.
- Update README, package docs, and repository guidance to document the config-relative file path contract.
- Reuse the shared config fixtures from both root and `exec` package tests, and remove the package-specific duplicate exec fixtures.

## Why

- Tausch is often installed as a binary while test configs and fixtures live inside the consuming repository. Resolving relative fixture paths from the test process working directory makes configs fragile when tests run from different packages.
- Resolving from the config file location makes fixture-backed stubs portable and matches the way users expect a YAML file with nearby fixtures to behave.

## Testing

- `go test ./internal/io` - passed
- `go test ./internal/cmd` - passed
- `go test ./internal/config` - passed
- `go test -count=1 ./exec` - passed
- `go test ./...` - passed
- `make build` - passed
- `make specs` - passed, 62 tests
- `make lint` - passed
- `make sec` - passed
- `make coverage` - passed, 98.3% statements
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
