### PR TITLE
docs(readme): clarify stub usage contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ make download
 make specs
 ```
 
-(`bin/build/make/go.mak:62-64`)
+Provided by `bin/build/make/go.mak`.
 
 ### Lint / format
 
@@ -99,7 +99,7 @@ Lint configuration lives in `.golangci.yml`.
 make sec
 ```
 
-(`bin/build/make/go.mak:95-97`)
+Provided by `bin/build/make/go.mak`.
 
 ### Coverage
 
@@ -109,7 +109,7 @@ The CI pipeline generates coverage profiles under `test/reports/`.
 make coverage
 ```
 
-(`bin/build/make/go.mak:84-86`)
+Provided by `bin/build/make/go.mak`.
 
 There are also helpers:
 

--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ cmds:
 ```
 
 > [!IMPORTANT]
-> Configure at most one non-empty encoded output stream for each stub. By default, a non-empty `stdout` value exits `0`; otherwise, Tausch falls back to `stderr` and exits `1`. If both streams are empty or omitted, the command exits `1` with no configured output. Set `exit_code` to override the default after output is written successfully; valid values are `0` through `255`. To stub a successful command that writes zero bytes, use `stdout: "text:"`. Configuring both `stdout` and `stderr` for one command is rejected.
+> Configure at most one non-empty encoded output stream for each stub. By default, a non-empty `stdout` value exits `0`; otherwise, Tausch falls back to `stderr` and exits `1`. If both streams are empty or omitted and `exit_code` is not set, the command exits `1` with no configured output. Set `exit_code` to override the final status after any configured output is written successfully; valid values are `0` through `255`. To stub a successful command that writes zero bytes, use `stdout: "text:"`. Configuring both `stdout` and `stderr` for one command is rejected.
 
-Payload values and `file:` paths are decoded only when the matching command is invoked, not when the YAML file is loaded.
+Payload values and `file:` paths are decoded only when the matching command is invoked, not when the YAML file is loaded. Unknown kinds or payloads without the `kind:data` separator make that invocation exit `1` with the decode error.
 
 ## 🎙️ Capture
 
@@ -201,6 +201,18 @@ Pass a config and, after `--`, call your usual command. The command tokens after
 
 > [!WARNING]
 > Command matching is exact and case-sensitive. For example, `tausch -- go version` matches `name: go version`, but not `name: Go Version` or `name: go version extra`.
+
+#### 🆘 Help
+
+Print command usage with any of the standard Go flag help forms:
+
+```bash
+tausch -h
+tausch -help
+tausch --help
+```
+
+Help output includes the invocation shape, config path resolution order, and available flags. These help invocations exit with status `1`.
 
 #### ✅ Example for stdout
 

--- a/exec/example_test.go
+++ b/exec/example_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/alexfalkowski/tausch/exec"
 )
@@ -25,7 +24,7 @@ func ExampleCommand() {
 
 	fmt.Print(string(out))
 	// Output:
-	// -- go version
+	// go version go1.24.4 darwin/amd64
 }
 
 func ExampleCommandContext() {
@@ -44,7 +43,7 @@ func ExampleCommandContext() {
 
 	fmt.Print(string(out))
 	// Output:
-	// -- go version
+	// go version go1.24.4 darwin/amd64
 }
 
 func setupExampleTausch() (func(), error) {
@@ -57,23 +56,17 @@ func setupExampleTausch() (func(), error) {
 		os.RemoveAll(dir)
 	}
 
-	tausch := filepath.Join(dir, "tausch")
-	if err := os.WriteFile(tausch, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\"\n"), 0o600); err != nil {
-		cleanup()
-		return nil, err
-	}
-	if err := os.Chmod(tausch, 0o700); err != nil {
-		cleanup()
-		return nil, err
-	}
-
 	oldPath := os.Getenv("PATH")
+	oldTausch, hadTausch := os.LookupEnv("TAUSCH_PATH")
 	oldConfig, hadConfig := os.LookupEnv("TAUSCH_CONFIG")
+
 	os.Setenv("PATH", dir)
-	os.Setenv("TAUSCH_CONFIG", "config.yml")
+	os.Setenv("TAUSCH_PATH", "../tausch")
+	os.Setenv("TAUSCH_CONFIG", "../test/configs/config.yml")
 
 	return func() {
 		os.Setenv("PATH", oldPath)
+		restoreEnv("TAUSCH_PATH", oldTausch, hadTausch)
 		restoreEnv("TAUSCH_CONFIG", oldConfig, hadConfig)
 		cleanup()
 	}, nil


### PR DESCRIPTION
## What

- Clarify configured output and exit-code behavior, including no-output stubs, malformed payload failures, and CLI help forms.
- Update executable `exec` package examples to show YAML-backed stub output through the real `tausch` binary instead of argv echo plumbing.
- Remove stale shared Makefile line references from agent workflow guidance.

## Why

- The documentation gap pass found several reader-facing contracts that were either missing or easy to misread, which could lead users to configure stubs incorrectly or misunderstand the Go wrapper examples.
- The examples now demonstrate the package consumer path the project actually supports: constructing standard command values while Tausch supplies configured stdout/stderr and exit status.

## Testing

- `make build` - passed
- `go test ./exec -run '^Example' -count=1` - passed
- `go test . -run TestReadmeCLIExamples -count=1` - passed
- `go run . -h` - printed the documented help output and exited with status `1` as documented
- `make specs` - passed
- `make lint` - passed
- `make sec` - passed
- `make coverage` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
