### PR TITLE
test(specs): add parallel fuzz coverage

### DIFF
--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -112,8 +112,7 @@ func TestCommandFallsBackToTauschPathForErrDot(t *testing.T) {
 }
 
 func TestCommandPrefixesDelimiter(t *testing.T) {
-	t.Setenv("PATH", t.TempDir())
-	t.Setenv("TAUSCH_PATH", filepath.Join(t.TempDir(), "tausch"))
+	t.Parallel()
 
 	cmd := exec.CommandContext(t.Context(), "-version", "--json")
 

--- a/exec/fuzz_test.go
+++ b/exec/fuzz_test.go
@@ -1,0 +1,29 @@
+package exec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alexfalkowski/tausch/exec"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzCommandPrefixesDelimiter(f *testing.F) {
+	f.Add("go", "version", "")
+	f.Add("go", "env", "GOPATH")
+	f.Add("-version", "--json", "")
+
+	f.Fuzz(func(t *testing.T, name, first, second string) {
+		if len(name)+len(first)+len(second) > 4096 {
+			t.Skip()
+		}
+
+		want := []string{"--", name, first, second}
+
+		command := exec.Command(name, first, second)
+		require.Equal(t, want, command.Args[1:])
+
+		commandContext := exec.CommandContext(context.Background(), name, first, second)
+		require.Equal(t, want, commandContext.Args[1:])
+	})
+}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestRunInvalidArgs(t *testing.T) {
+	t.Parallel()
+
 	args := []string{"- x"}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -37,6 +39,8 @@ func TestRunConfigError(t *testing.T) {
 }
 
 func TestRunMissingConfig(t *testing.T) {
+	t.Parallel()
+
 	args := []string{
 		"-config", "cfg.yml",
 		"--",
@@ -52,6 +56,8 @@ func TestRunMissingConfig(t *testing.T) {
 }
 
 func TestRunMissingCommand(t *testing.T) {
+	t.Parallel()
+
 	args := []string{
 		"-config", "../../test/configs/config.yml",
 		"--",
@@ -67,6 +73,8 @@ func TestRunMissingCommand(t *testing.T) {
 }
 
 func TestRunMultipleOutputs(t *testing.T) {
+	t.Parallel()
+
 	args := []string{
 		"-config", "../../test/configs/multiple_outputs.yml",
 		"--",
@@ -82,6 +90,8 @@ func TestRunMultipleOutputs(t *testing.T) {
 }
 
 func TestRunStdoutWriteError(t *testing.T) {
+	t.Parallel()
+
 	args := []string{
 		"-config", "../../test/configs/stdout_invalid_base64.yml",
 		"--",
@@ -146,6 +156,8 @@ func TestRunStdoutExitCode(t *testing.T) {
 }
 
 func TestRunStderrWriteError(t *testing.T) {
+	t.Parallel()
+
 	args := []string{
 		"-config", "../../test/configs/stderr_invalid_base64.yml",
 		"--",
@@ -195,6 +207,8 @@ func TestRunStderrExitCode(t *testing.T) {
 }
 
 func TestRunNoOutputExitCode(t *testing.T) {
+	t.Parallel()
+
 	args := []string{
 		"-config", "../../test/configs/exit_code.yml",
 		"--",

--- a/internal/cmd/fuzz_test.go
+++ b/internal/cmd/fuzz_test.go
@@ -1,0 +1,58 @@
+package cmd_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/alexfalkowski/tausch/internal/cmd"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+func FuzzRunWritesConfiguredStdout(f *testing.F) {
+	f.Add("go version")
+	f.Add(" go version ")
+	f.Add("-version --json")
+
+	f.Fuzz(func(t *testing.T, rawName string) {
+		if len(rawName) > 1024 || !utf8.ValidString(rawName) || strings.ContainsRune(rawName, 0) {
+			t.Skip()
+		}
+
+		name := strings.TrimSpace(rawName)
+		if name == "" {
+			t.Skip()
+		}
+
+		data, err := yaml.Marshal(fuzzConfig{
+			Cmds: []fuzzCommand{
+				{Name: name, Stdout: "text:ok"},
+			},
+		})
+		require.NoError(t, err)
+
+		config := filepath.Join(t.TempDir(), "config.yml")
+		require.NoError(t, os.WriteFile(config, data, 0o600))
+
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		code := cmd.Run(stdout, stderr, []string{"-config", config, "--", rawName})
+
+		require.Zero(t, code)
+		require.Equal(t, "ok", stdout.String())
+		require.Empty(t, stderr.String())
+	})
+}
+
+type fuzzConfig struct {
+	Cmds []fuzzCommand `yaml:"cmds"`
+}
+
+type fuzzCommand struct {
+	Name   string `yaml:"name"`
+	Stdout string `yaml:"stdout"`
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestDecodeSuccess(t *testing.T) {
+	t.Parallel()
+
 	c, err := config.Decode("../../test/configs/config.yml")
 
 	require.NoError(t, err)
@@ -15,6 +17,8 @@ func TestDecodeSuccess(t *testing.T) {
 }
 
 func TestDecodeExitCode(t *testing.T) {
+	t.Parallel()
+
 	c, err := config.Decode("../../test/configs/exit_code.yml")
 
 	require.NoError(t, err)
@@ -24,6 +28,8 @@ func TestDecodeExitCode(t *testing.T) {
 }
 
 func TestDecodeError(t *testing.T) {
+	t.Parallel()
+
 	values := []string{
 		"../../test/configs/none.yml",
 		"../../test/configs/empty.yml",
@@ -31,6 +37,8 @@ func TestDecodeError(t *testing.T) {
 
 	for _, value := range values {
 		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+
 			c, err := config.Decode(value)
 
 			require.Error(t, err)
@@ -40,6 +48,8 @@ func TestDecodeError(t *testing.T) {
 }
 
 func TestDecodeMultipleOutputs(t *testing.T) {
+	t.Parallel()
+
 	c, err := config.Decode("../../test/configs/multiple_outputs.yml")
 
 	require.Nil(t, c)
@@ -48,6 +58,8 @@ func TestDecodeMultipleOutputs(t *testing.T) {
 }
 
 func TestDecodeInvalidExitCode(t *testing.T) {
+	t.Parallel()
+
 	c, err := config.Decode("../../test/configs/invalid_exit_code.yml")
 
 	require.Nil(t, c)
@@ -56,6 +68,8 @@ func TestDecodeInvalidExitCode(t *testing.T) {
 }
 
 func TestGetCommandNilCommand(t *testing.T) {
+	t.Parallel()
+
 	c := &config.Config{Cmds: []*config.Command{nil}}
 
 	command, err := c.GetCommand("go version")
@@ -65,6 +79,8 @@ func TestGetCommandNilCommand(t *testing.T) {
 }
 
 func TestGetCommandExactMatch(t *testing.T) {
+	t.Parallel()
+
 	command := &config.Command{Name: "go version", Stdout: "text:go version"}
 	c := &config.Config{
 		Cmds: []*config.Command{
@@ -84,6 +100,8 @@ func TestGetCommandExactMatch(t *testing.T) {
 
 	for _, value := range []string{"Go version", "go", " go version "} {
 		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := c.GetCommand(value)
 
 			require.Nil(t, got)

--- a/internal/config/fuzz_test.go
+++ b/internal/config/fuzz_test.go
@@ -1,0 +1,70 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/tausch/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzConfigValidate(f *testing.F) {
+	f.Add("go version", "text:go version", "", 0, false)
+	f.Add("go bob", "", "text:go bob", 127, true)
+	f.Add("go version", "text:go version", "text:warning", 0, false)
+	f.Add("go bob", "", "", -1, true)
+	f.Add("go bob", "", "", 256, true)
+
+	f.Fuzz(func(t *testing.T, name, stdout, stderr string, exitCode int, hasExitCode bool) {
+		if len(name)+len(stdout)+len(stderr) > 4096 {
+			t.Skip()
+		}
+
+		var code *int
+		if hasExitCode {
+			code = &exitCode
+		}
+
+		c := &config.Config{
+			Cmds: []*config.Command{
+				{Name: name, Stdout: stdout, Stderr: stderr, ExitCode: code},
+			},
+		}
+
+		err := c.Validate()
+		switch {
+		case stdout != "" && stderr != "":
+			require.ErrorIs(t, err, config.ErrMultipleOutputs)
+		case hasExitCode && (exitCode < 0 || exitCode > 255):
+			require.ErrorIs(t, err, config.ErrInvalidExitCode)
+		default:
+			require.NoError(t, err)
+		}
+	})
+}
+
+func FuzzConfigGetCommand(f *testing.F) {
+	f.Add("go version", "go version")
+	f.Add("go version", "Go Version")
+	f.Add("go version", " go version ")
+	f.Add("", "")
+
+	f.Fuzz(func(t *testing.T, name, query string) {
+		if len(name)+len(query) > 4096 {
+			t.Skip()
+		}
+
+		command := &config.Command{Name: name}
+		c := &config.Config{Cmds: []*config.Command{nil, command}}
+
+		got, err := c.GetCommand(query)
+		if query == name {
+			require.NoError(t, err)
+			require.Same(t, command, got)
+
+			return
+		}
+
+		require.Nil(t, got)
+		require.ErrorIs(t, err, config.ErrCommandNotFound)
+	})
+}

--- a/internal/flag/fuzz_test.go
+++ b/internal/flag/fuzz_test.go
@@ -1,0 +1,26 @@
+package flag_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/alexfalkowski/tausch/internal/flag"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzParseCommandName(f *testing.F) {
+	f.Add("go", "version")
+	f.Add(" test ", "my code")
+	f.Add("-config", "cfg.yml")
+
+	f.Fuzz(func(t *testing.T, first, second string) {
+		if len(first)+len(second) > 4096 {
+			t.Skip()
+		}
+
+		values, err := flag.Parse(io.Discard, []string{"--", first, second})
+		require.NoError(t, err)
+		require.Equal(t, strings.TrimSpace(strings.Join([]string{first, second}, " ")), values.Name())
+	})
+}

--- a/internal/flag/values_test.go
+++ b/internal/flag/values_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestValuesSuccess(t *testing.T) {
+	t.Parallel()
+
 	args := []string{"-config", "cfg.yml", "test", "my", "code"}
 
 	f, err := flag.Parse(io.Discard, args)
@@ -98,6 +100,8 @@ func (c configCase) assert(t *testing.T) {
 }
 
 func TestValuesError(t *testing.T) {
+	t.Parallel()
+
 	args := []string{"- x"}
 
 	_, err := flag.Parse(io.Discard, args)

--- a/internal/io/fuzz_test.go
+++ b/internal/io/fuzz_test.go
@@ -1,0 +1,74 @@
+package io_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/alexfalkowski/tausch/internal/io"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzWriteText(f *testing.F) {
+	f.Add("")
+	f.Add(" test\n")
+	f.Add("a:b")
+
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 4096 {
+			t.Skip()
+		}
+
+		buffer := &bytes.Buffer{}
+		wrote, err := io.Write(buffer, "text:"+data, "")
+
+		require.NoError(t, err)
+		require.True(t, wrote)
+		require.Equal(t, data, buffer.String())
+	})
+}
+
+func FuzzWriteBase64(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte(" test\n"))
+	f.Add([]byte{0x00, 0x01, 0xff})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 4096 {
+			t.Skip()
+		}
+
+		buffer := &bytes.Buffer{}
+		wrote, err := io.Write(buffer, "base64:"+base64.StdEncoding.EncodeToString(data), "")
+
+		require.NoError(t, err)
+		require.True(t, wrote)
+		require.Equal(t, string(data), buffer.String())
+	})
+}
+
+func FuzzWriteKindNotFound(f *testing.F) {
+	f.Add("bob", "test")
+	f.Add("", "test")
+	f.Add("unsupported", "")
+
+	f.Fuzz(func(t *testing.T, kind, data string) {
+		if len(kind)+len(data) > 4096 {
+			t.Skip()
+		}
+
+		value := kind + ":" + data
+		prefix, _, _ := strings.Cut(value, ":")
+		if prefix == "text" || prefix == "file" || prefix == "base64" {
+			t.Skip()
+		}
+
+		buffer := &bytes.Buffer{}
+		wrote, err := io.Write(buffer, value, "")
+
+		require.ErrorIs(t, err, io.ErrKindNotFound)
+		require.False(t, wrote)
+		require.Empty(t, buffer.Bytes())
+	})
+}

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestWriteSuccess(t *testing.T) {
+	t.Parallel()
+
 	want := []byte(" test\n")
 	file := filepath.Join(t.TempDir(), "sample.txt")
 	require.NoError(t, os.WriteFile(file, want, 0o600))
@@ -29,6 +31,8 @@ func TestWriteSuccess(t *testing.T) {
 
 	for _, tt := range values {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			buffer := &bytes.Buffer{}
 			wrote, err := io.Write(buffer, tt.value, tt.dir)
 
@@ -40,6 +44,8 @@ func TestWriteSuccess(t *testing.T) {
 }
 
 func TestWriteError(t *testing.T) {
+	t.Parallel()
+
 	values := []string{
 		"base64:123456",
 		"file:../../test/configs/none.txt",
@@ -47,6 +53,8 @@ func TestWriteError(t *testing.T) {
 
 	for _, value := range values {
 		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+
 			buffer := &bytes.Buffer{}
 			wrote, err := io.Write(buffer, value, "")
 
@@ -58,6 +66,8 @@ func TestWriteError(t *testing.T) {
 }
 
 func TestWriteKindNotFound(t *testing.T) {
+	t.Parallel()
+
 	values := []string{
 		"bob:test",
 		"text",
@@ -67,6 +77,8 @@ func TestWriteKindNotFound(t *testing.T) {
 
 	for _, value := range values {
 		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+
 			buffer := &bytes.Buffer{}
 			wrote, err := io.Write(buffer, value, "")
 
@@ -78,6 +90,8 @@ func TestWriteKindNotFound(t *testing.T) {
 }
 
 func TestWritePreservesDataAfterFirstColon(t *testing.T) {
+	t.Parallel()
+
 	buffer := &bytes.Buffer{}
 	wrote, err := io.Write(buffer, "text:a:b", "")
 
@@ -87,6 +101,8 @@ func TestWritePreservesDataAfterFirstColon(t *testing.T) {
 }
 
 func TestWriteEmpty(t *testing.T) {
+	t.Parallel()
+
 	buffer := &bytes.Buffer{}
 	wrote, err := io.Write(buffer, "", "")
 
@@ -96,6 +112,8 @@ func TestWriteEmpty(t *testing.T) {
 }
 
 func TestWriteWriterError(t *testing.T) {
+	t.Parallel()
+
 	wrote, err := io.Write(test.FailingWriter{}, "text:test", "")
 
 	require.ErrorIs(t, err, test.ErrWriteFailed)

--- a/main_test.go
+++ b/main_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestReadmeCLIExamples(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		wantStdout string
@@ -41,6 +43,8 @@ func TestReadmeCLIExamples(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			stdout := &bytes.Buffer{}
 			stderr := &bytes.Buffer{}
 


### PR DESCRIPTION
## What

- Added fuzz targets for command argument shaping, CLI command matching, config validation and lookup, flag parsing, and encoded output writing.
- Marked deterministic Go tests and subtests as parallel while leaving environment and working-directory mutating cases serial.
- Bounded fuzz-generated input sizes so longer fuzz runs stay predictable and avoid unnecessary memory churn.

## Why

- Improves confidence around parser and command-stub contracts by exercising broader input spaces through the existing Go fuzz support in bin.
- Reduces routine suite wall time where tests use isolated buffers, fixtures, subprocesses, or read-only data.
- Keeps process-global tests conservative, so parallel execution does not race environment variables or working-directory state.

## Testing

- `make build` - passed
- `make specs` - passed
- `make lint` - passed; reported only the existing gomodguard deprecation warning and 0 issues
- `make sec` - passed; govulncheck and Trivy reported no vulnerabilities
- `make coverage` - passed; statement coverage reported 98.3%
- `make fuzz package=internal/config name=FuzzConfigValidate fuzztime=1s` - passed
- `make fuzz package=internal/config name=FuzzConfigGetCommand fuzztime=1s` - passed
- `make fuzz package=internal/io name=FuzzWriteText fuzztime=1s` - passed
- `make fuzz package=internal/io name=FuzzWriteBase64 fuzztime=1s` - passed
- `make fuzz package=internal/io name=FuzzWriteKindNotFound fuzztime=1s` - passed
- `make fuzz package=internal/flag name=FuzzParseCommandName fuzztime=1s` - passed
- `make fuzz package=exec name=FuzzCommandPrefixesDelimiter fuzztime=1s` - passed
- `make fuzz package=internal/cmd name=FuzzRunWritesConfiguredStdout fuzztime=1s` - passed
