### PR TITLE
test(internal): surface fuzz and benchmark entrypoints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
       - run: make sec
       - run: make build
       - run: make specs
+      - run: make benchmarks
       - save_cache:
           name: save go build cache
           key: tausch-go-build-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,53 @@ include bin/build/make/help.mak
 include bin/build/make/go.mak
 include bin/build/make/git.mak
 
+.PHONY: benchmarks benchmark-cli benchmark-config benchmark-flag benchmark-io fuzz-smoke fuzz-cmd fuzz-config fuzz-flag fuzz-io fuzz-exec
+
 # Build the cli.
 build:
 	@go build
+
+# Run all repository Go benchmarks.
+benchmarks: benchmark-cli benchmark-config benchmark-flag benchmark-io
+
+# Benchmark the end-to-end CLI stub path.
+benchmark-cli:
+	@$(MAKE) benchmark
+
+# Benchmark config loading and command lookup.
+benchmark-config:
+	@$(MAKE) benchmark package=internal/config
+
+# Benchmark CLI flag parsing and command-name derivation.
+benchmark-flag:
+	@$(MAKE) benchmark package=internal/flag
+
+# Benchmark configured output decoding and writing.
+benchmark-io:
+	@$(MAKE) benchmark package=internal/io
+
+# Run bounded smoke fuzzing for all repository fuzz targets.
+fuzz-smoke: fuzz-cmd fuzz-config fuzz-flag fuzz-io fuzz-exec
+
+# Fuzz the end-to-end CLI stdout path.
+fuzz-cmd:
+	@$(MAKE) fuzz package=internal/cmd name=FuzzRunWritesConfiguredStdout fuzztime=1s
+
+# Fuzz config validation and command lookup.
+fuzz-config:
+	@$(MAKE) fuzz package=internal/config name=FuzzConfigValidate fuzztime=1s
+	@$(MAKE) fuzz package=internal/config name=FuzzConfigGetCommand fuzztime=1s
+
+# Fuzz CLI argument parsing and command-name derivation.
+fuzz-flag:
+	@$(MAKE) fuzz package=internal/flag name=FuzzParseCommandName fuzztime=1s
+
+# Fuzz output decoding and writing.
+fuzz-io:
+	@$(MAKE) fuzz package=internal/io name=FuzzWriteText fuzztime=1s
+	@$(MAKE) fuzz package=internal/io name=FuzzWriteBase64 fuzztime=1s
+	@$(MAKE) fuzz package=internal/io name=FuzzWriteKindNotFound fuzztime=1s
+
+# Fuzz the public exec wrapper delimiter contract.
+fuzz-exec:
+	@$(MAKE) fuzz package=exec name=FuzzCommandPrefixesDelimiter fuzztime=1s

--- a/README.md
+++ b/README.md
@@ -272,8 +272,32 @@ Build the CLI from the repository root:
 make build
 ```
 
-Run the tests after the binary exists:
+Run the repository checks after the binary exists:
 
 ```bash
-go test ./...
+make specs
+```
+
+Run the benchmark aggregate:
+
+```bash
+make benchmarks
+```
+
+Run one benchmark package:
+
+```bash
+make benchmark package=internal/io
+```
+
+Run bounded smoke fuzzing for all fuzz targets:
+
+```bash
+make fuzz-smoke
+```
+
+Run one fuzz target:
+
+```bash
+make fuzz package=internal/io name=FuzzWriteText
 ```

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/alexfalkowski/tausch/internal/cmd"
+)
+
+// BenchmarkRunStdout tracks the CLI's hot stub path: parse argv, decode YAML,
+// find the command, decode stdout, and write the configured bytes.
+func BenchmarkRunStdout(b *testing.B) {
+	args := []string{
+		"-config", "test/configs/config.yml",
+		"--",
+		"go", "version",
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		stdout.Reset()
+		stderr.Reset()
+
+		code := cmd.Run(stdout, stderr, args)
+		if code != 0 {
+			b.Fatalf("expected exit code 0, got %d: %s", code, stderr.String())
+		}
+		if stdout.Len() == 0 {
+			b.Fatal("expected stdout")
+		}
+	}
+}

--- a/exec/fuzz_test.go
+++ b/exec/fuzz_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzCommandPrefixesDelimiter protects the public exec wrapper's compatibility
+// contract: target command tokens are always passed after tausch's -- delimiter.
 func FuzzCommandPrefixesDelimiter(f *testing.F) {
 	f.Add("go", "version", "")
 	f.Add("go", "env", "GOPATH")

--- a/internal/cmd/fuzz_test.go
+++ b/internal/cmd/fuzz_test.go
@@ -13,6 +13,8 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
+// FuzzRunWritesConfiguredStdout protects the end-to-end CLI path for arbitrary
+// command names that are serialized through YAML and parsed from argv.
 func FuzzRunWritesConfiguredStdout(f *testing.F) {
 	f.Add("go version")
 	f.Add(" go version ")

--- a/internal/config/benchmark_test.go
+++ b/internal/config/benchmark_test.go
@@ -1,0 +1,50 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/tausch/internal/config"
+)
+
+// BenchmarkDecode tracks the cost of loading and validating the YAML config on
+// each CLI invocation.
+func BenchmarkDecode(b *testing.B) {
+	b.ReportAllocs()
+
+	for range b.N {
+		c, err := config.Decode("../../test/configs/config.yml")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if c == nil {
+			b.Fatal("expected config")
+		}
+	}
+}
+
+// BenchmarkGetCommand tracks exact command lookup cost as config entries grow.
+func BenchmarkGetCommand(b *testing.B) {
+	command := &config.Command{Name: "go version"}
+	c := &config.Config{
+		Cmds: []*config.Command{
+			nil,
+			{Name: "go env GOPATH"},
+			{Name: "go test ./..."},
+			command,
+			{Name: "go build"},
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		got, err := c.GetCommand("go version")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if got != command {
+			b.Fatal("expected matching command")
+		}
+	}
+}

--- a/internal/config/fuzz_test.go
+++ b/internal/config/fuzz_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzConfigValidate protects YAML-decoded command invariants from arbitrary
+// command names, output payloads, and exit code values.
 func FuzzConfigValidate(f *testing.F) {
 	f.Add("go version", "text:go version", "", 0, false)
 	f.Add("go bob", "", "text:go bob", 127, true)
@@ -42,6 +44,8 @@ func FuzzConfigValidate(f *testing.F) {
 	})
 }
 
+// FuzzConfigGetCommand protects exact command-name matching, which is the CLI's
+// user-visible lookup contract.
 func FuzzConfigGetCommand(f *testing.F) {
 	f.Add("go version", "go version")
 	f.Add("go version", "Go Version")

--- a/internal/flag/benchmark_test.go
+++ b/internal/flag/benchmark_test.go
@@ -1,0 +1,26 @@
+package flag_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/alexfalkowski/tausch/internal/flag"
+)
+
+// BenchmarkParseCommandName tracks the CLI argument parsing and command-name
+// derivation performed before every config lookup.
+func BenchmarkParseCommandName(b *testing.B) {
+	args := []string{"-config", "config.yml", "--", "go", "version"}
+
+	b.ReportAllocs()
+
+	for range b.N {
+		values, err := flag.Parse(io.Discard, args)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if values.Name() != "go version" {
+			b.Fatalf("expected go version, got %q", values.Name())
+		}
+	}
+}

--- a/internal/flag/fuzz_test.go
+++ b/internal/flag/fuzz_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzParseCommandName protects the CLI argument boundary where command tokens
+// after -- are joined into the config lookup name.
 func FuzzParseCommandName(f *testing.F) {
 	f.Add("go", "version")
 	f.Add(" test ", "my code")

--- a/internal/io/benchmark_test.go
+++ b/internal/io/benchmark_test.go
@@ -1,0 +1,57 @@
+package io_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/alexfalkowski/tausch/internal/io"
+)
+
+// BenchmarkWriteText tracks text payload decoding and write throughput for
+// recorded command output.
+func BenchmarkWriteText(b *testing.B) {
+	value := "text:" + strings.Repeat("x", 1024)
+	buffer := &bytes.Buffer{}
+
+	b.ReportAllocs()
+	b.SetBytes(1024)
+	b.ResetTimer()
+
+	for range b.N {
+		buffer.Reset()
+
+		wrote, err := io.Write(buffer, value, "")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !wrote {
+			b.Fatal("expected write")
+		}
+	}
+}
+
+// BenchmarkWriteBase64 tracks base64 payload decoding and write throughput for
+// recorded command output bytes.
+func BenchmarkWriteBase64(b *testing.B) {
+	data := []byte(strings.Repeat("x", 1024))
+	value := "base64:" + base64.StdEncoding.EncodeToString(data)
+	buffer := &bytes.Buffer{}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+
+	for range b.N {
+		buffer.Reset()
+
+		wrote, err := io.Write(buffer, value, "")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !wrote {
+			b.Fatal("expected write")
+		}
+	}
+}

--- a/internal/io/fuzz_test.go
+++ b/internal/io/fuzz_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzWriteText protects user-controlled text payloads, where configured
+// command output can be empty or contain separators after the kind prefix.
 func FuzzWriteText(f *testing.F) {
 	f.Add("")
 	f.Add(" test\n")
@@ -29,6 +31,8 @@ func FuzzWriteText(f *testing.F) {
 	})
 }
 
+// FuzzWriteBase64 protects base64 payload decoding for arbitrary recorded
+// command output bytes.
 func FuzzWriteBase64(f *testing.F) {
 	f.Add([]byte(""))
 	f.Add([]byte(" test\n"))
@@ -48,6 +52,8 @@ func FuzzWriteBase64(f *testing.F) {
 	})
 }
 
+// FuzzWriteKindNotFound protects the kind:data parser from accepting unknown
+// output encodings.
 func FuzzWriteKindNotFound(f *testing.F) {
 	f.Add("bob", "test")
 	f.Add("", "test")


### PR DESCRIPTION
## What

- Added Go benchmark entrypoints for the CLI stdout path, config decode and lookup, flag parsing, and output decoding.
- Added grouped `make benchmarks` and `make fuzz-smoke` targets, with rationale comments on fuzz entrypoints and README development docs for benchmark and fuzz commands.
- Added CircleCI coverage for `make benchmarks` after specs so benchmark entrypoints are exercised in CI.

## Why

- Makes performance-sensitive stub paths visible through repository-owned benchmark commands instead of ad hoc `go test` invocations.
- Keeps fuzz coverage discoverable through a bounded smoke target and documents the supported local workflow.

## Testing

- `make build` - passed
- `make specs` - passed
- `make benchmarks` - passed
- `make fuzz-smoke` - passed
- `make lint` - passed with the existing `gomodguard` deprecation warning and 0 issues
- `make sec` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
