### PR TITLE
build(make): run bounded fuzzing in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
       - run: make build
       - run: make specs
       - run: make benchmarks
+      - run: make fuzzes
       - save_cache:
           name: save go build cache
           key: tausch-go-build-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ make dep
 make lint
 make build
 make specs
+make fuzzes
 ```
 
 Notes:
@@ -196,7 +197,7 @@ Tests in `exec/exec_test.go` rely on the `tausch` binary being present (either v
 
 ## CI / release
 
-- CircleCI config: `.circleci/config.yml` wraps the core local validation sequence (`make dep`, `make lint`, `make sec`, `make build`, `make specs`, `make coverage`) with CI setup, cleanup, cache, and upload steps.
+- CircleCI config: `.circleci/config.yml` wraps the core local validation sequence (`make dep`, `make lint`, `make sec`, `make build`, `make specs`, `make benchmarks`, `make fuzzes`, `make coverage`) with CI setup, cleanup, cache, and upload steps.
 - GoReleaser config: `.goreleaser.yml`.
 
 ## Gotchas

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@ include bin/build/make/help.mak
 include bin/build/make/go.mak
 include bin/build/make/git.mak
 
-.PHONY: benchmarks benchmark-cli benchmark-config benchmark-flag benchmark-io fuzz-smoke fuzz-cmd fuzz-config fuzz-flag fuzz-io fuzz-exec
-
 # Build the cli.
 build:
 	@go build
@@ -28,7 +26,7 @@ benchmark-io:
 	@$(MAKE) benchmark package=internal/io
 
 # Run bounded smoke fuzzing for all repository fuzz targets.
-fuzz-smoke: fuzz-cmd fuzz-config fuzz-flag fuzz-io fuzz-exec
+fuzzes: fuzz-cmd fuzz-config fuzz-flag fuzz-io fuzz-exec
 
 # Fuzz the end-to-end CLI stdout path.
 fuzz-cmd:

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ make benchmark package=internal/io
 Run bounded smoke fuzzing for all fuzz targets:
 
 ```bash
-make fuzz-smoke
+make fuzzes
 ```
 
 Run one fuzz target:


### PR DESCRIPTION
## What

- Rename the bounded fuzz aggregate target from `fuzz-smoke` to `fuzzes`.
- Run `make fuzzes` in CircleCI after the benchmark step.
- Update contributor-facing docs to use the new target name and remove the unnecessary local `.PHONY` declaration.

## Why

- Makes the fuzz aggregate command name match the repository target naming style while intentionally breaking compatibility with the old `fuzz-smoke` target.
- Ensures CI exercises the bounded fuzz targets instead of leaving them as a local-only workflow.

## Testing

- `make fuzzes` - passed
- `make lint` - passed with the existing `gomodguard` deprecation warning.
