### PR TITLE
build(make): bound fuzz smoke runs by count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+fuzztime ?= 1000x
+
 include bin/build/make/help.mak
 include bin/build/make/go.mak
 include bin/build/make/git.mak
@@ -25,28 +27,28 @@ benchmark-flag:
 benchmark-io:
 	@$(MAKE) benchmark package=internal/io
 
-# Run bounded smoke fuzzing for all repository fuzz targets.
+# Run count-bounded smoke fuzzing for all repository fuzz targets.
 fuzzes: fuzz-cmd fuzz-config fuzz-flag fuzz-io fuzz-exec
 
 # Fuzz the end-to-end CLI stdout path.
 fuzz-cmd:
-	@$(MAKE) fuzz package=internal/cmd name=FuzzRunWritesConfiguredStdout fuzztime=1s
+	@$(MAKE) fuzz package=internal/cmd name=FuzzRunWritesConfiguredStdout
 
 # Fuzz config validation and command lookup.
 fuzz-config:
-	@$(MAKE) fuzz package=internal/config name=FuzzConfigValidate fuzztime=1s
-	@$(MAKE) fuzz package=internal/config name=FuzzConfigGetCommand fuzztime=1s
+	@$(MAKE) fuzz package=internal/config name=FuzzConfigValidate
+	@$(MAKE) fuzz package=internal/config name=FuzzConfigGetCommand
 
 # Fuzz CLI argument parsing and command-name derivation.
 fuzz-flag:
-	@$(MAKE) fuzz package=internal/flag name=FuzzParseCommandName fuzztime=1s
+	@$(MAKE) fuzz package=internal/flag name=FuzzParseCommandName
 
 # Fuzz output decoding and writing.
 fuzz-io:
-	@$(MAKE) fuzz package=internal/io name=FuzzWriteText fuzztime=1s
-	@$(MAKE) fuzz package=internal/io name=FuzzWriteBase64 fuzztime=1s
-	@$(MAKE) fuzz package=internal/io name=FuzzWriteKindNotFound fuzztime=1s
+	@$(MAKE) fuzz package=internal/io name=FuzzWriteText
+	@$(MAKE) fuzz package=internal/io name=FuzzWriteBase64
+	@$(MAKE) fuzz package=internal/io name=FuzzWriteKindNotFound
 
 # Fuzz the public exec wrapper delimiter contract.
 fuzz-exec:
-	@$(MAKE) fuzz package=exec name=FuzzCommandPrefixesDelimiter fuzztime=1s
+	@$(MAKE) fuzz package=exec name=FuzzCommandPrefixesDelimiter

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Run one benchmark package:
 make benchmark package=internal/io
 ```
 
-Run bounded smoke fuzzing for all fuzz targets:
+Run count-bounded smoke fuzzing for all fuzz targets:
 
 ```bash
 make fuzzes
@@ -300,4 +300,11 @@ Run one fuzz target:
 
 ```bash
 make fuzz package=internal/io name=FuzzWriteText
+```
+
+The repository default is `fuzztime=1000x`, so fuzzing is bounded by run count
+instead of wall-clock duration. Override it when needed:
+
+```bash
+make fuzz package=internal/io name=FuzzWriteText fuzztime=250x
 ```


### PR DESCRIPTION
## What

- Default repository fuzz runs to `fuzztime=1000x` so smoke fuzzing is bounded by execution count instead of wall-clock duration.
- Remove per-target `fuzztime=1s` overrides from the aggregate fuzz targets so they inherit the repository default while still allowing callers to override it.
- Document the count-bounded default and a single-target override example in the README.

## Why

- Duration-bounded fuzz smoke runs can overrun in slower environments and cause timeouts.
- A fixed execution count keeps CI and local validation deterministic while preserving quick fuzz coverage across the existing targets.

## Testing

- `make fuzzes` - passed; each fuzz target reported around 1000 executions.
- `make lint` - passed with 0 issues; emitted the existing `gomodguard` deprecation warning.
