### PR TITLE
docs(readme): clarify command and configuration contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,11 +47,11 @@ Notes:
 make build
 ```
 
-(`Makefile:6-7`)
+The root `Makefile` owns the `build` target.
 
 ### Dependencies
 
-Provided via included makefiles from the `bin/` submodule (`Makefile:1-3` includes `bin/build/make/go.mak`):
+Provided by `bin/build/make/go.mak`, which the root `Makefile` includes:
 
 ```bash
 make dep
@@ -104,9 +104,13 @@ Provided by `bin/build/make/go.mak`.
 
 ### Coverage
 
-The CI pipeline generates coverage profiles under `test/reports/`.
+`make specs` generates the coverage profile under `test/reports/`; the coverage
+target renders that profile. Build the current CLI and generate a fresh profile
+before rendering coverage:
 
 ```bash
+make build
+make specs
 make coverage
 ```
 
@@ -129,7 +133,7 @@ external tools:
 - `make create-diagram`
 - `make create-certs`
 - `make analyse`
-- `make money`
+- `make cost`
 
 ## Project structure
 
@@ -151,11 +155,13 @@ The CLI is designed to be invoked as:
 tausch -config path/to/config.yml -- <your command as a string>
 ```
 
-Internally, the “command name” is the args after `--` joined by spaces (`internal/flag/values.go:45-47`). That string must match the `name` field in the YAML config.
+Internally, `Values.Name` in `internal/flag/values.go` joins the args after `--`
+with spaces. That string must match the `name` field in the YAML config.
 
 ### Config file discovery
 
-Config path is resolved in this order (`internal/flag/values.go:29-42`):
+`Values.Config` in `internal/flag/values.go` resolves the config path in this
+order:
 
 1. `-config <path>`
 2. `TAUSCH_CONFIG` environment variable
@@ -177,8 +183,10 @@ If the prefix is unknown, decoding fails with `ErrKindNotFound`.
 
 The `exec` package returns an `*exec.Cmd` that actually executes the `tausch` binary:
 
-- It resolves the binary via `exec.LookPath("tausch")`, and falls back to `TAUSCH_PATH` if not found (`exec/exec.go:15-22`).
-- It prefixes arguments with `--` before the real command (`exec/exec.go:24-26`).
+- The `executable` helper in `exec/exec.go` resolves the binary via
+  `exec.LookPath("tausch")` and falls back to `TAUSCH_PATH` if not found.
+- The `commandArgs` helper in `exec/exec.go` prefixes arguments with `--`
+  before the real command.
 
 Tests in `exec/exec_test.go` rely on the `tausch` binary being present (either via `PATH` including an absolute repo root or via `TAUSCH_PATH`). Do not rely on `PATH=.`; Go's `exec.LookPath` can reject current-directory matches and cause the wrapper to fall back to `TAUSCH_PATH`.
 
@@ -207,4 +215,8 @@ Tests in `exec/exec_test.go` rely on the `tausch` binary being present (either v
   root, so run `make build` first when needed. Do not override or extend the
   shared `specs` target locally; keep the build-before-specs ordering in
   workflow guidance and CI.
-- **Command name matching**: command lookup is string-based (joined args after `--`); minor spacing differences will cause `command not found` errors.
+- **Command name matching**: command lookup is string-based (joined args after
+  `--`). Shell spacing or quoting that produces the same argument tokens does
+  not matter. Only differences that change the derived string, such as case
+  changes, added non-whitespace content, or embedded literal whitespace, cause
+  `command not found` errors.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ tausch -config config.yml -- go version
 
 The configuration is a YAML document with a top-level `cmds` list. Each command entry has a `name` and may set `stdout`, `stderr`, or `exit_code`.
 
+> [!WARNING]
+> Unknown YAML keys are ignored, so a misspelled field does not fail config
+> loading. Keep command names unique; if multiple entries have the same exact
+> name, Tausch uses the first one in `cmds`.
+
 The `stdout` and `stderr` values use a `kind:data` format:
 
 ```txt
@@ -117,7 +122,7 @@ cmds:
     stdout: file:test/stdout/go_version.txt
   - name: go bob
     stderr: file:test/stderr/go_bob.txt
-    exit_code: 127
+    exit_code: 2
   - name: grep needle file.txt
     exit_code: 1
 ```
@@ -141,7 +146,7 @@ For stderr:
 
 ```bash
 go bob 2> test/stderr/go_bob.txt
-echo $? # copy this into exit_code when needed
+echo $? # copy the captured status (2 for this example) into exit_code
 ```
 
 For a command where you want both streams in one file:
@@ -158,7 +163,7 @@ cmds:
     stdout: file:test/stdout/go_version.txt
   - name: go bob
     stderr: file:test/stderr/go_bob.txt
-    exit_code: 127
+    exit_code: 2
 ```
 
 To refresh a fixture, rerun the same redirect command:
@@ -212,7 +217,7 @@ tausch -help
 tausch --help
 ```
 
-Help output includes the invocation shape, config path resolution order, and available flags. These help invocations exit with status `1`.
+Help output includes the invocation shape, config path resolution order, and available flags. These help invocations write usage to stderr and exit with status `1`.
 
 #### ✅ Example for stdout
 

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -28,6 +28,10 @@ func Command(name string, arg ...string) *exec.Cmd {
 // CommandContext returns an [exec.Cmd] that runs the given command through the
 // `tausch` CLI.
 //
+// It mirrors [os/exec.CommandContext]: ctx controls the lifetime of the
+// `tausch` process and must be non-nil. The returned [exec.Cmd] retains the
+// standard command cancellation lifecycle.
+//
 // The returned command executes the `tausch` binary and prefixes the provided
 // command with `--`, so this:
 //

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,11 +32,12 @@ const maxExitCode = 255
 
 // Decode reads a YAML configuration file from path and decodes it into a [Config].
 //
-// The YAML is expected to match the tausch schema (a top-level `cmds` list). This
-// function validates command-level invariants, but it does not validate that any
-// commands are present or that stdout/stderr payload strings are valid
-// `kind:data` values. The decoded config records the absolute directory of path
-// so relative file payloads can be resolved from the config file location.
+// The YAML is expected to match the tausch schema (a top-level `cmds` list).
+// Unknown YAML fields are ignored. This function validates command-level
+// invariants, but it does not validate that any commands are present or that
+// stdout/stderr payload strings are valid `kind:data` values. The decoded config
+// records the absolute directory of path so relative file payloads can be
+// resolved from the config file location.
 //
 // The returned *Config is ready to be queried with [Config.GetCommand].
 //
@@ -112,8 +113,9 @@ func (c *Config) Validate() error {
 //
 // Matching is string-based and exact (case-sensitive). The tausch CLI derives name
 // by joining the command tokens (typically the args after `--`) with spaces.
-// Because of this, small differences in whitespace or quoting can cause lookups
-// to fail.
+// Shell spacing or quoting that produces the same tokens does not affect that
+// derived name; differences that change the resulting string do affect lookup.
+// If more than one command matches, GetCommand returns the first one in [Config.Cmds].
 //
 // If no command matches, the error will be [ErrCommandNotFound].
 func (c *Config) GetCommand(name string) (*Command, error) {

--- a/internal/flag/doc.go
+++ b/internal/flag/doc.go
@@ -29,7 +29,9 @@
 //	"go version"
 //
 // This derived name must match the `name` field in the YAML config exactly.
-// Because matching is string-based, differences in spacing or quoting will cause
+// Shell spacing or quoting that produces the same argument tokens does not
+// affect the name. Only differences that change the derived string, such as case
+// changes, added non-whitespace content, or embedded literal whitespace, cause
 // lookups to fail.
 //
 // # Config path resolution


### PR DESCRIPTION
## What

- Clarify CLI help output, captured exit status, command matching, YAML unknown-field and duplicate-name behavior, and the exec wrapper cancellation contract.
- Update contributor workflow guidance with stable source references, the current cost target, and the build/specs/coverage ordering.

## Why

- Prevent users and maintainers from relying on stale command examples or ambiguous configuration and process behavior.

## Testing

- `make lint` - passed with 0 issues; the existing `gomodguard` deprecation warning remains.
- `make build` - passed.
- `make specs` - passed, 97 tests.
- `make coverage` - passed, 98.3% statement coverage.
- `go doc -all ./exec`, `go doc -all ./internal/config`, and `go doc -all ./internal/flag` - passed.
- Targeted CLI/config checks - passed for help stderr and exit status, `go bob` exit 2, whitespace normalization, unknown YAML keys, and first duplicate-name selection.

AI-assisted-by: [Codex](https://openai.com/codex/)
